### PR TITLE
Hero card three-state redesign + ghost button polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,10 @@
       // 'done'     = workout completed today → Undo visible, action buttons hidden
       // 'skipped'  = rest day logged today  → Undo visible, action buttons hidden
       const history = data.history || [];
-      const heroState = skippedToday ? 'skipped' : (actionTakenToday ? 'done' : 'default');
+      // Derive state from todayEntry (the source of truth), not actionTakenToday.
+      // actionDate and history can drift out of sync on a partial Supabase write,
+      // so using todayEntry prevents a false 'done' state with no actual log entry.
+      const heroState = skippedToday ? 'skipped' : (todayEntry ? 'done' : 'default');
       const sugDays = data[heroWorkout.id] ? daysSince(data[heroWorkout.id]) : null;
 
       // Eyebrow label
@@ -1482,6 +1485,13 @@
       const mainBtn = document.getElementById('main-done-btn');
       const skipBtn = document.getElementById('skip-btn');
       const undoBtn = document.getElementById('undo-btn');
+
+      // Re-enable all three hero buttons: setButtonsDisabled(true) fires at the
+      // start of every action and is never explicitly reversed — render() is the
+      // natural place to restore interactive state after a round-trip completes.
+      mainBtn.disabled = false;
+      skipBtn.disabled = false;
+      undoBtn.disabled = false;
 
       mainBtn.hidden = heroState !== 'default';
       skipBtn.hidden = heroState !== 'default';

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'wmw-v24';
+const CACHE = 'wmw-v25';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

- **Hero card three-state machine**: Default (nothing logged), Completed, and Skipped/Rest Day are now fully distinct — the right buttons and icon show for each state, with nothing irrelevant cluttering the card
- **Stacked icon layout**: hero icon is centered on its own line above the title, so two-line workout names wrap cleanly without breaking the layout
- **Undo and Log for yesterday** restyled as proper ghost buttons with a visible border and 44px min tap target
- **iOS arrow emoji fix**: `↩` replaced with a Lucide `undo-2` icon in both buttons
- Service worker bumped to `wmw-v23`

## Hero card states in detail

| State | Icon | Title | Subtitle | Buttons |
|---|---|---|---|---|
| Default | Workout icon (purple) | Workout name | Last done date | Done! + Skip Today |
| Completed today | Workout icon (purple) | Workout name | "Completed today" | Undo only |
| Skipped / rest day | Moon icon (amber) | "Rest Day" | "Day off logged" | Undo only |

## Test plan

- [ ] Default state: hero shows workout icon + name + last-done text; Done! and Skip Today visible; Undo hidden
- [ ] After tapping Done!: card switches to Completed state; Done! and Skip Today gone; Undo ghost button appears with `undo-2` icon and workout name
- [ ] After tapping Skip Today: card switches to Rest Day state; moon icon (amber); title "Rest Day"; subtitle "Day off logged"; Undo ghost button
- [ ] Tapping Undo from either post-action state correctly reverts and returns to Default state
- [ ] Log for yesterday button in workout rows has `undo-2` icon, visible border, comfortable tap target
- [ ] No `↩` emoji renders anywhere on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Today card shows clear states (Next Up, Completed, Day Off) with dynamic icons, amber rest-day styling, and refined hero layout.

* **UI Behavior**
  * Action buttons adapt to state with context-aware labels (including Undo) and conditional visibility; undo/skip flows restored.

* **History & Logs**
  * Log and history controls use inline icons and improved spacing/alignment for consistent visuals.

* **Chores**
  * Service worker cache version updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->