### PR TITLE
Add test mode (?test=true URL param)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1394,7 +1394,7 @@
     }
 
     // ── Other Activity helpers ───────────────────────────────────────────────
-    const OTHER_ACTIVITIES_KEY = 'wmw_other_activities';
+    const OTHER_ACTIVITIES_KEY = TEST_MODE ? 'wmw_test_other_activities' : 'wmw_other_activities';
 
     function loadOtherActivities() {
       try {
@@ -1953,7 +1953,8 @@
     if (TEST_MODE) {
       document.getElementById('test-banner').hidden = false;
       document.getElementById('test-reset-btn').onclick = () => {
-        localStorage.removeItem('wmw_test');
+        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(OTHER_ACTIVITIES_KEY);
         render();
       };
     }


### PR DESCRIPTION
- TEST_MODE constant: set true when URL contains ?test=true
- STORAGE_KEY is wmw_test in test mode, wmw_v1 otherwise — real and test data are completely isolated in localStorage
- loadData and saveData both skip all Supabase reads/writes when TEST_MODE is true; the app runs in localStorage-only mode
- Test mode banner: amber bar above the header with text "TEST MODE — no real data affected" and a Reset button that clears wmw_test from localStorage and re-renders the app to a clean state
- In normal mode (TEST_MODE = false) behaviour is identical to before; the wmw_test key is never touched

No service worker bump (no cacheable assets changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Test Mode with a visible banner and Reset button to clear test data.
  * Test Mode can be enabled via a URL parameter to isolate test data from production.
  * When active, data is read/written locally and remote storage writes are skipped to prevent contamination.
  * Test-specific storage keys ensure test data remains separate from production data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->