### PR TITLE
Fail build loudly if Supabase env vars are not set

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   # Inject Supabase credentials from Netlify environment variables into index.html at deploy time.
   # Set SUPABASE_URL and SUPABASE_KEY in: Netlify Dashboard → Site → Environment variables
-  command = "sed -i \"s|%%SUPABASE_URL%%|${SUPABASE_URL}|g; s|%%SUPABASE_KEY%%|${SUPABASE_KEY}|g\" index.html"
+  command = "{ [ -n \"${SUPABASE_URL}\" ] || { echo 'ERROR: SUPABASE_URL is not set'; exit 1; }; } && { [ -n \"${SUPABASE_KEY}\" ] || { echo 'ERROR: SUPABASE_KEY is not set'; exit 1; }; } && sed -i \"s|%%SUPABASE_URL%%|${SUPABASE_URL}|g; s|%%SUPABASE_KEY%%|${SUPABASE_KEY}|g\" index.html"
   publish = "."
 
 [build.environment]


### PR DESCRIPTION
## Summary

- Adds a pre-flight check to the Netlify build command that exits immediately with a non-zero code and a clear error message if `SUPABASE_URL` or `SUPABASE_KEY` are missing or empty
- Prevents a silent broken deploy where the placeholder tokens (`%%SUPABASE_URL%%`, `%%SUPABASE_KEY%%`) get replaced with empty strings and the app ships without working credentials

## Test plan

- [ ] Trigger a Netlify deploy with both env vars set — confirm build succeeds as before
- [ ] Remove `SUPABASE_URL` from Netlify env vars and redeploy — confirm build fails with `ERROR: SUPABASE_URL is not set`
- [ ] Same for `SUPABASE_KEY`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the deployment pipeline with validation checks to verify critical configuration settings before the build process begins. This prevents incomplete deployments and provides users with clear, actionable error messages when required settings are missing, enabling faster identification and resolution of configuration issues and improving overall deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->