### PR TITLE
fix: use max(sequence)+1 for backfill inserts to prevent sequence collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,6 @@ Requires `apple-touch-icon.png` (180×180 PNG, generated from `icon.svg`) for a 
 
 The service worker (`sw.js`) precaches the Supabase JS client from the CDN alongside the app's own files. This means the app loads correctly offline after the first visit — no network request to the CDN needed.
 
-## Known Issues
-
-- **Backfill entries overwriting each other** (issue #24 follow-up): when multiple backfill entries are logged for different past days in the same session, only the most recent one may appear in history. Diagnostic `console.log` statements have been added around the Supabase INSERT path (`[backfill]`, `[saveData]`, `[loadData]` prefixes) to capture sequence values and error details. Root cause is under investigation.
-
 ## Next Steps
 
 1. Multi-user support with logins and a public guest view

--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.0.35';
+    const VERSION = '1.0.36';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -1292,13 +1292,19 @@
             });
             if (upsertErr) throw upsertErr;
           }
-          // Insert the unsynced history entries
-          const offlineRows = unsynced.map(e => ({
+          // Insert the unsynced history entries.
+          // Query the current max sequence first so offline rows never collide
+          // with gaps left by undo deletions (same fix as in saveData).
+          const { data: maxSeqRow, error: maxSeqErr } = await sb.from('history')
+            .select('sequence').order('sequence', { ascending: false }).limit(1).maybeSingle();
+          if (maxSeqErr) throw maxSeqErr;
+          const offlineBase = (maxSeqRow?.sequence ?? -1) + 1;
+          const offlineRows = unsynced.map((e, i) => ({
             type:     e.type,
             date:     e.date,
             advanced: e.advanced ?? true,
             note:     e.note ?? null,
-            sequence: (local.history || []).indexOf(e),
+            sequence: offlineBase + i,
           }));
           console.log('[loadData] Offline sync — inserting unsynced rows:', offlineRows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
           const { data: inserted, error: insErr } = await sb.from('history')
@@ -1334,6 +1340,9 @@
         const data = {
           rotationIndex: state.rotation_index ?? 0,
           actionDate:    state.action_date   ?? null,
+          // Track the highest sequence value currently in Supabase so new inserts
+          // always use max + 1, even when undo has left gaps in the sequence column.
+          _maxSeq: historyRows.reduce((m, r) => Math.max(m, r.sequence ?? -1), -1),
           history: historyRows.map(r => ({ type: r.type, date: r.date, advanced: r.advanced, note: r.note ?? undefined, _sid: r.id })),
         };
 
@@ -1380,15 +1389,17 @@
         // Insert only new entries — those not yet synced (no _sid means never written to Supabase)
         const newEntries = (data.history || []).filter(e => !e._sid);
         if (newEntries.length) {
-          // sequence = the entry's position in the full history array, so ordering
-          // by sequence always reproduces insertion order even across batch inserts
-          // that share the same created_at timestamp.
-          const rows = newEntries.map(e => ({
+          // Base sequence = max existing Supabase sequence + 1, so new inserts
+          // never collide with gaps left by undo deletions. _maxSeq is set by
+          // loadData when reading from Supabase; fall back to synced-entry count
+          // for the rare case where data came from the localStorage fallback.
+          const baseSeq = (typeof data._maxSeq === 'number' ? data._maxSeq : data.history.filter(e => e._sid).length - 1) + 1;
+          const rows = newEntries.map((e, i) => ({
             type: e.type,
             date: e.date,
             advanced: e.advanced ?? true,
             note: e.note ?? null,
-            sequence: data.history.indexOf(e),
+            sequence: baseSeq + i,
           }));
           console.log('[saveData] Inserting rows into Supabase:', rows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
           const { data: inserted, error: insErr } = await sb.from('history').insert(rows).select('id, sequence');
@@ -1397,14 +1408,15 @@
             throw insErr;
           }
           console.log('[saveData] Supabase INSERT succeeded:', inserted);
-          // Match by sequence rather than array position — insert order is not
-          // guaranteed to be preserved in the returned rows.
+          // Match returned rows by sequence value — insert order is not guaranteed.
           const insertedBySeq = {};
           inserted.forEach(row => { insertedBySeq[row.sequence] = row.id; });
-          newEntries.forEach(e => {
-            const seq = data.history.indexOf(e);
+          newEntries.forEach((e, i) => {
+            const seq = baseSeq + i;
             if (insertedBySeq[seq] !== undefined) e._sid = insertedBySeq[seq];
           });
+          // Keep _maxSeq current so subsequent saves in the same session are correct.
+          data._maxSeq = baseSeq + newEntries.length - 1;
           localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
         }
         lastSyncedAt = Date.now();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'wmw-v35';
+const CACHE = 'wmw-v36';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Root cause

Every new backfill INSERT was computing its `sequence` value as `data.history.indexOf(e)` — the entry's position in the local array. When an **undo** deletes a row from Supabase, it leaves a gap in the `sequence` column. The next backfill lands at local position N, but sequence N still exists in Supabase, causing a unique-constraint collision. The INSERT fails silently inside `saveData`'s catch block, the entry stays in localStorage with no `_sid`, and the next `loadData` overwrites localStorage with fresh Supabase data that doesn't include it — so the entry disappears entirely.

Console logs from v1.0.35 confirmed this: every backfill was getting `sequence: 64` because the local array had 64 entries but Supabase still had an existing row at sequence 64 (the last entry was not the one that was undone).

## Fix

- **`loadData` (Supabase read path):** compute `_maxSeq = max(sequence)` across all returned rows and store it on the data object. Persisted to localStorage on every successful load, so it's also available in the offline fallback.
- **`saveData`:** derive `baseSeq` from `_maxSeq + 1` (falling back to synced-entry count when `_maxSeq` is absent), then assign `sequence = baseSeq + i` for each new entry. Updates `_maxSeq` after a successful INSERT so back-to-back saves in the same session also get correct values.
- **`loadData` offline sync path:** queries the current max sequence from Supabase (one lightweight `SELECT`) before inserting unsynced entries, using the same max+1 logic.

## Test plan

- [ ] Log a workout normally, undo it, then log two separate backfill entries for different past days — both should persist and appear in history
- [ ] Log multiple backfill entries in a single session — all should stack correctly
- [ ] Verify console shows distinct, incrementing sequence values for each `[saveData] Inserting rows` log

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline history handling with enhanced sequence management to ensure unique, monotonic numbering for better data consistency during synchronization.

* **Chores**
  * Updated service worker cache version.
  * Removed outdated "Known Issues" section from documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->