### PR TITLE
fix: guard against read-after-write timing in backfill sequence + history

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.0.36';
+    const VERSION = '1.0.37';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -1337,12 +1337,17 @@
         const state = stateRes.data || {};
         const historyRows = historyRes.data || [];
 
+        // _maxSeq must be the true highest sequence in Supabase so new inserts
+        // always use max + 1. Take the max of (a) what Supabase just returned
+        // and (b) what localStorage already recorded — guards against read-after-
+        // write timing where a just-inserted row hasn't appeared in SELECT yet.
+        const supabaseMaxSeq = historyRows.reduce((m, r) => Math.max(m, r.sequence ?? -1), -1);
+        const localMaxSeq    = typeof local._maxSeq === 'number' ? local._maxSeq : -1;
+
         const data = {
           rotationIndex: state.rotation_index ?? 0,
           actionDate:    state.action_date   ?? null,
-          // Track the highest sequence value currently in Supabase so new inserts
-          // always use max + 1, even when undo has left gaps in the sequence column.
-          _maxSeq: historyRows.reduce((m, r) => Math.max(m, r.sequence ?? -1), -1),
+          _maxSeq: Math.max(supabaseMaxSeq, localMaxSeq),
           history: historyRows.map(r => ({ type: r.type, date: r.date, advanced: r.advanced, note: r.note ?? undefined, _sid: r.id })),
         };
 
@@ -1351,6 +1356,20 @@
           if (type !== 'off' && (!data[type] || date > data[type])) {
             data[type] = date;
           }
+        }
+
+        // Guard against read-after-write timing: if localStorage holds entries
+        // that were already synced (_sid set) but didn't appear in this SELECT
+        // result, re-append them so they aren't silently lost when we overwrite
+        // localStorage below. Entries absent from Supabase with no _sid are
+        // handled by the offline-sync path above, not here.
+        const supabaseSids = new Set(historyRows.map(r => r.id));
+        const missed = (local.history || []).filter(e => e._sid && !supabaseSids.has(e._sid));
+        if (missed.length) {
+          console.warn('[loadData] Supabase SELECT missed', missed.length,
+            'recently-synced entries — re-appending from localStorage:',
+            missed.map(e => ({ type: e.type, date: e.date, _sid: e._sid })));
+          data.history = [...data.history, ...missed];
         }
 
         lastSyncedAt = Date.now();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'wmw-v36';
+const CACHE = 'wmw-v37';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## What was wrong

Two related bugs, both caused by a **read-after-write timing gap**: a row inserted into Supabase may not appear in the very next `SELECT` response.

### Bug 1 — sequence always the same value
`_maxSeq` was computed only from the Supabase SELECT result. When that SELECT missed a just-inserted row, `_maxSeq` stayed at the pre-insert value, so the next backfill calculated the same `baseSeq` and assigned a duplicate sequence number. Logs confirmed: both inserts got `sequence: 66`.

**Fix:** `_maxSeq = Math.max(supabaseMaxSeq, localMaxSeq)`. localStorage is always updated with the sequence assigned by each successful INSERT (done by `saveData`), so it acts as a floor — even if SELECT lags, we never repeat a sequence.

### Bug 2 — localStorage overwritten without the first backfill entry
`loadData` read N rows from Supabase (missing the first backfill), then unconditionally overwrote localStorage with those N rows. The second `confirmBackfill` pushed its new entry onto those N rows, saved N+1 to localStorage — silently dropping the first backfill entry entirely.

**Fix:** After building the Supabase-derived history, compare its `_sid` set against localStorage. Any entry with a `_sid` (previously confirmed synced to Supabase) that's absent from the SELECT result is re-appended to `data.history` before localStorage is overwritten. A `console.warn` fires when this triggers so the timing issue stays visible.

## Test plan
- [ ] Log two backfill entries for different past days — both should persist in history and calendar
- [ ] Console should show distinct, incrementing sequence values for each `[saveData] Inserting rows` log
- [ ] If the timing issue triggers, `[loadData] Supabase SELECT missed` warning should appear — entries should still be present in UI

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data synchronization between local and cloud storage to prevent history entry loss.
  * Improved handling of timing gaps during data synchronization operations.

* **Chores**
  * Bumped application version to 1.0.37.
  * Updated service worker cache to ensure fresh assets are delivered to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->