### PR TITLE
fix: hero card shows wrong name after logging non-scheduled workout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A single-file mobile-first PWA that follows a fixed workout rotation and tells you what's next.
 
-**Current version: 1.0.39**
+**Current version: 1.0.40**
 
 Live at: https://habits.chrisaug.com
 

--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.0.39';
+    const VERSION = '1.0.40';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -2504,7 +2504,7 @@
 
       // Hero card stays on the completed workout for the rest of the day.
       // Only flip to the next rotation item when a new day begins.
-      const heroWorkout = (actionTakenToday && !skippedToday && !otherToday && todayEntry)
+      const heroWorkout = (!skippedToday && !otherToday && todayEntry)
         ? (WORKOUTS.find(w => w.id === todayEntry.type) || nextInRotation)
         : nextInRotation;
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'wmw-v39';
+const CACHE = 'wmw-v40';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

- Hero card was showing the rotation-suggested workout name (e.g. "Peloton Ride") instead of the workout actually logged (e.g. "Upper Push") when the user logs a non-scheduled workout
- Root cause: `heroWorkout` was gated on `actionTakenToday` (`data.actionDate === today`), but the non-scheduled workout logger never sets `data.actionDate` — so `heroWorkout` always fell back to `nextInRotation` for those entries
- Fix: removed `actionTakenToday` from the `heroWorkout` condition so it uses `todayEntry` as sole source of truth, consistent with how `heroState` was already computed

Closes #68

## Test plan

- [ ] Log the rotation-suggested workout → hero card shows correct name
- [ ] Log a different workout than suggested → hero card shows the logged workout name (not the suggested one)
- [ ] Skip today → hero card shows "Rest Day" (unchanged)
- [ ] Log Other Activity → hero card shows the activity name (unchanged)
- [ ] Undo a non-scheduled workout → card returns to default state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v1.0.40 Release Notes

* **Improvements**
  * Version updated to 1.0.40
  * Enhanced hero workout selection logic to display workouts more consistently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->