### PR TITLE
fix: hero card shows correct name after logging non-rotation workout

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.0.42';
+    const VERSION = '1.0.43';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -1329,6 +1329,7 @@
       document.getElementById('suggestion-name').textContent =
         heroState === 'skipped' ? 'Rest Day' :
         heroState === 'other'   ? (todayEntry?.note || 'Other Activity') :
+        heroState === 'done'    ? (WORKOUTS.find(w => w.id === todayEntry.type)?.name || heroWorkout.name) :
         heroWorkout.name;
 
       // Subtitle
@@ -1366,6 +1367,7 @@
         const undoLabel =
           heroState === 'skipped' ? 'Rest Day' :
           heroState === 'other'   ? (todayEntry?.note || 'Other Activity') :
+          heroState === 'done'    ? (WORKOUTS.find(w => w.id === todayEntry.type)?.name || heroWorkout.name) :
           heroWorkout.name;
         undoBtn.innerHTML = '';
         const undoIcon = document.createElement('i');

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'wmw-v42';
+const CACHE = 'wmw-v43';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

- Hero card was displaying the rotation's suggested workout name instead of the name of the workout that was actually logged
- Root cause: the `'done'` state fell through to `heroWorkout.name`, which could resolve to `nextInRotation` when `actionTakenToday` was stale
- Fix: both the suggestion-name element and the Undo button label now look up the name directly from `todayEntry.type` (the history source of truth) when `heroState === 'done'`

Closes #68

## Test plan

- [ ] Log the suggested rotation workout → hero card shows correct name
- [ ] Log a workout that differs from the rotation suggestion → hero card shows the logged workout name (not the rotation suggestion)
- [ ] Undo button reads "Undo [logged workout name]" in both cases
- [ ] Skip and Other Activity states unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved display of specific workout names in the hero section and undo functionality.

* **Chores**
  * Updated app version to 1.0.43.
  * Updated service worker cache to ensure offline functionality works with the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->