### PR TITLE
Drop offline sync: flip to Supabase-first writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,11 @@ The hero card locks for the day when `data.actionDate === todayStr()`. Any log a
 ### Modal → log action order
 Always call `closeXModal()` BEFORE calling an async log function (`markRowDone`, `logSkip`, `logOtherActivity`). The `isProcessing` guard and `setButtonsDisabled` run at the start of every log function — if the modal is still open, its buttons stay frozen.
 
+### Action function error pattern
+`saveData` throws on Supabase failure — do NOT use `try/finally` alone. All action functions that call `saveData` must follow:
+`try { ...await saveData(data); render(data); showToast(...); } catch { setButtonsDisabled(false); showToast('Could not save — check your connection'); } finally { isProcessing = false; }`
+Exception: `confirmBackfill` uses `isProcessing` but not `setButtonsDisabled` — its catch block only needs `showToast(...)`, not `setButtonsDisabled(false)`.
+
 ## Architecture guardrails
 Because this is a simple personal app:
 

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.3.53';
+    const VERSION = '1.3.54';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -188,65 +188,62 @@
     }
 
     async function saveData(data, deletedSid = null) {
-      // Always write localStorage immediately so the fallback is always fresh
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-      if (!sb || TEST_MODE) return; // localStorage-only or test mode — skip Supabase
-      try {
-        // Upsert the single state row (rotation position + today's lock)
-        const { error: stateErr } = await sb.from('state').upsert({
-          id: 1,
-          rotation_index: data.rotationIndex ?? 0,
-          action_date:    data.actionDate    ?? null,
-        });
-        if (stateErr) throw stateErr;
-
-        // If this save was triggered by an undo, delete only that one row
-        if (deletedSid) {
-          const { error: delErr } = await sb.from('history').delete().eq('id', deletedSid);
-          if (delErr) throw delErr;
-        }
-
-        // Insert only new entries — those not yet synced (no _sid means never written to Supabase)
-        const newEntries = (data.history || []).filter(e => !e._sid);
-        if (newEntries.length) {
-          // Base sequence = max existing Supabase sequence + 1, so new inserts
-          // never collide with gaps left by undo deletions. _maxSeq is set by
-          // loadData when reading from Supabase; fall back to synced-entry count
-          // for the rare case where data came from the localStorage fallback.
-          const baseSeq = (typeof data._maxSeq === 'number' ? data._maxSeq : data.history.filter(e => e._sid).length - 1) + 1;
-          const rows = newEntries.map((e, i) => ({
-            type: e.type,
-            date: e.date,
-            advanced: e.advanced ?? true,
-            note: e.note ?? null,
-            sequence: baseSeq + i,
-          }));
-          console.log('[saveData] Inserting rows into Supabase:', rows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
-          const { data: inserted, error: insErr } = await sb.from('history').insert(rows).select('id, sequence');
-          if (insErr) {
-            console.error('[saveData] Supabase INSERT failed:', insErr, 'rows attempted:', rows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
-            throw insErr;
-          }
-          console.log('[saveData] Supabase INSERT succeeded:', inserted);
-          // Match returned rows by sequence value — insert order is not guaranteed.
-          const insertedBySeq = {};
-          inserted.forEach(row => { insertedBySeq[row.sequence] = row.id; });
-          newEntries.forEach((e, i) => {
-            const seq = baseSeq + i;
-            if (insertedBySeq[seq] !== undefined) e._sid = insertedBySeq[seq];
-          });
-          // Keep _maxSeq current so subsequent saves in the same session are correct.
-          data._maxSeq = baseSeq + newEntries.length - 1;
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-        }
-        lastSyncedAt = Date.now();
-        syncOffline  = false;
-        updateSyncStamp();
-      } catch (err) {
-        console.warn('Supabase write failed (data saved locally):', err);
-        syncOffline = true;
-        updateSyncStamp();
+      if (!sb || TEST_MODE) {
+        // No Supabase connection — write to localStorage only (test mode / offline dev)
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+        return;
       }
+
+      // Write to Supabase FIRST — throws on any failure so callers can handle the error
+      const { error: stateErr } = await sb.from('state').upsert({
+        id: 1,
+        rotation_index: data.rotationIndex ?? 0,
+        action_date:    data.actionDate    ?? null,
+      });
+      if (stateErr) throw stateErr;
+
+      // If this save was triggered by an undo, delete only that one row
+      if (deletedSid) {
+        const { error: delErr } = await sb.from('history').delete().eq('id', deletedSid);
+        if (delErr) throw delErr;
+      }
+
+      // Insert the newly-pushed entry (no _sid means not yet in Supabase)
+      const newEntries = (data.history || []).filter(e => !e._sid);
+      if (newEntries.length) {
+        // Base sequence = max existing Supabase sequence + 1, so new inserts
+        // never collide with gaps left by undo deletions.
+        const baseSeq = (typeof data._maxSeq === 'number' ? data._maxSeq : data.history.filter(e => e._sid).length - 1) + 1;
+        const rows = newEntries.map((e, i) => ({
+          type: e.type,
+          date: e.date,
+          advanced: e.advanced ?? true,
+          note: e.note ?? null,
+          sequence: baseSeq + i,
+        }));
+        console.log('[saveData] Inserting rows into Supabase:', rows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
+        const { data: inserted, error: insErr } = await sb.from('history').insert(rows).select('id, sequence');
+        if (insErr) {
+          console.error('[saveData] Supabase INSERT failed:', insErr, 'rows attempted:', rows.map(r => ({ type: r.type, date: r.date, sequence: r.sequence })));
+          throw insErr;
+        }
+        console.log('[saveData] Supabase INSERT succeeded:', inserted);
+        // Match returned rows by sequence value — insert order is not guaranteed.
+        const insertedBySeq = {};
+        inserted.forEach(row => { insertedBySeq[row.sequence] = row.id; });
+        newEntries.forEach((e, i) => {
+          const seq = baseSeq + i;
+          if (insertedBySeq[seq] !== undefined) e._sid = insertedBySeq[seq];
+        });
+        // Keep _maxSeq current so subsequent saves in the same session are correct.
+        data._maxSeq = baseSeq + newEntries.length - 1;
+      }
+
+      // Supabase confirmed — update localStorage as read cache only
+      lastSyncedAt = Date.now();
+      syncOffline  = false;
+      updateSyncStamp();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     }
 
     function todayStr() {
@@ -350,6 +347,9 @@
         await saveData(data);
         render(data);
         showToast('Logged \u2713');
+      } catch {
+        setButtonsDisabled(false);
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing = false;
       }
@@ -408,6 +408,9 @@
         await saveData(data);
         render(data);
         showToast('Day off logged');
+      } catch {
+        setButtonsDisabled(false);
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing = false;
       }
@@ -478,6 +481,9 @@
           ? (last.note || 'other activity')
           : (WORKOUTS.find(w => w.id === last.type)?.name ?? last.type);
         showToast(`Undone \u2014 ${name}`);
+      } catch {
+        setButtonsDisabled(false);
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing = false;
       }
@@ -500,6 +506,9 @@
         await saveData(data);
         render(data);
         showToast('Logged \u2713');
+      } catch {
+        setButtonsDisabled(false);
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing = false;
       }
@@ -657,6 +666,9 @@
         await saveData(data);
         render(data);
         showToast(`${name} logged`);
+      } catch {
+        setButtonsDisabled(false);
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing = false;
       }
@@ -1030,6 +1042,8 @@
                             (WORKOUTS.find(w => w.id === newType)?.name ?? newType);
         showToast(wasEdit ? `${displayName} updated` : `${displayName} logged`);
 
+      } catch {
+        showToast('Could not save \u2014 check your connection');
       } finally {
         isProcessing  = false;
         backfillSaving = false;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v53';
+const CACHE = 'habits-v54';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

- `saveData` now writes to Supabase first; localStorage is updated only after Supabase confirms success
- If Supabase fails, the error is thrown — no fallback write to localStorage occurs
- Added `catch` blocks to all action functions (`markDone`, `skipToday`, `undoLastEntry`, `logYesterday`, `logOtherActivity`, `confirmBackfill`) to show an error toast and re-enable buttons on failure
- Removed `syncOffline` fallback path from `saveData`
- Updated CLAUDE.md with the action function error pattern

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for save operations with clearer connectivity feedback when issues occur
  * Enhanced sync reliability between local cache and remote data storage
  * Better handling of undo and delete operations
  
* **Chores**
  * Service worker cache refreshed for improved offline functionality
  * Version bumped to 1.3.54

<!-- end of auto-generated comment: release notes by coderabbit.ai -->