### PR TITLE
Fix Stats weight chart for weight-only users

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.13**
+**Current version: 1.5.14**
 
 Live at: https://habits.chrisaug.com
 

--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.13';
+    const VERSION = '1.5.14';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';
@@ -2062,6 +2062,8 @@
       // ── Empty state ───────────────────────────────────────────────────────
       if (realWorkouts.length === 0) {
         container.innerHTML = '<div class="stats-empty">No data yet.</div>';
+        document.getElementById('view-stats').appendChild(document.getElementById('weight-chart-section'));
+        renderWeightChart();
         if (typeof lucide !== 'undefined') lucide.createIcons();
         return;
       }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v13';
+const CACHE = 'habits-v14';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- render the Stats weight chart even when there are no workout entries
- keep the existing empty workout message while still appending and rendering the weight chart section
- bump the app and service worker versions to 1.5.14 / habits-v14

## Testing
- node --check app.js

AI-assisted: Codex