### PR TITLE
Improve FTUX onboarding flow and add signup URL default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ intentionally simple. Live at https://habits.chrisaug.com.
 - Read workout icons from `workout_library.icon` when workout rows are already loaded; do not re-derive display icons from category in app code
 - Today and Stats should show explicit dark loading placeholders during Supabase reads and manual syncs instead of rendering partial empty content
 - Persist saved user rotations through the `save_user_rotation` Supabase RPC instead of separate client-side delete/insert calls
-- Keep tutorial copy aligned with the live product: custom workout rotation controls and Today tab card visibility should be reflected in onboarding text
+- Keep tutorial copy aligned with the live product: custom workout sequence controls and Today tab card visibility should be reflected in onboarding text
+- FTUX and Tutorial now share a single 6-step onboarding overlay; screen 3 is the live starting-sequence picker, and the custom builder should return to onboarding step 3 on cancel or step 4 after a successful save
 - Keep `app.js` as the runtime spine; shared helpers may live in small support files like `shared.js` and `data.js`, while feature code belongs in feature modules
 - Supabase JS `.upsert()` calls must pass `onConflict` as a comma-separated string, not an array
 - If Supabase is unreachable, show an error toast — no offline writes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ intentionally simple. Live at https://habits.chrisaug.com.
 - Read workout icons from `workout_library.icon` when workout rows are already loaded; do not re-derive display icons from category in app code
 - Today and Stats should show explicit dark loading placeholders during Supabase reads and manual syncs instead of rendering partial empty content
 - Persist saved user rotations through the `save_user_rotation` Supabase RPC instead of separate client-side delete/insert calls
-- Keep tutorial copy aligned with the live product: custom workout rotation controls and Today tab card visibility should be reflected in onboarding text
+- Keep tutorial copy aligned with the live product: custom workout sequence controls and Today tab card visibility should be reflected in onboarding text
+- FTUX and Tutorial now share a single 6-step onboarding overlay; screen 3 is the live starting-sequence picker, and the custom builder should return to onboarding step 3 on cancel or step 4 after a successful save
 - Keep `app.js` as the runtime spine; shared helpers may live in small support files like `shared.js` and `data.js`, while feature code belongs in feature modules
 - Supabase JS `.upsert()` calls must pass `onConflict` as a comma-separated string, not an array
 - Reuse shared "last done" thresholds and labels across surfaces instead of re-inventing per-view logic

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.22**
+**Current version: 1.5.25**
 
 Live at: https://habits.chrisaug.com
 
@@ -13,7 +13,7 @@ The calendar is the centerpiece: a simple, honest record of the days you showed 
 
 Planned for a small user base — a handful of people with logins plus a public guest view — the app will stay intentionally simple. No integrations, no notifications, no noise.
 
-## Rotation
+## Workout Sequence
 
 Peloton alternates with every other workout. Yoga appears every 4th workout overall. The full 12-step cycle:
 
@@ -33,9 +33,9 @@ Peloton alternates with every other workout. Yoga appears every 4th workout over
 | 12 | **Yoga** |
 | → repeat | |
 
-The default rotation is position-based, not time-based — it always picks up where it left off regardless of how many days pass between workouts.
+The default workout sequence is position-based, not time-based — it always picks up where it left off regardless of how many days pass between workouts.
 
-Each signed-in user can now build and save a custom rotation in Settings. New accounts first choose a pre-built program or build their own from scratch, and existing accounts can reset to a program later from Settings. Until a user saves a custom rotation with at least 2 workouts, the app keeps using the default built-in rotation above.
+Each signed-in user can now build and save a custom workout sequence in Settings. New accounts move through a 6-step onboarding flow that explains the app, then choose a pre-built sequence or build their own from scratch. Existing accounts can reset to a program later from Settings. Until a user saves a custom sequence with at least 2 workouts, the app keeps using the default built-in sequence above.
 
 Pre-built programs live in Supabase and are loaded after auth into `state.programs`. Global programs are visible to everyone, while personal programs are scoped to their owner.
 
@@ -48,12 +48,12 @@ Bottom nav: **Today · Log · Stats** (three tabs)
 The Today tab is a daily habit dashboard with customizable cards. All entry happens via modals — the tab itself is read-only with action buttons.
 
 **Workout card**
-- Shows today's suggested workout (Next Up) with rotation, Done!, and Undo logic unchanged
-- Uses the signed-in user's saved rotation when available, whether it came from a pre-built program or the custom builder; otherwise falls back to the built-in default rotation
-- **Done!** — logs the workout and advances the rotation
+- Shows today's suggested workout (Next Up) with sequence, Done!, and Undo logic unchanged
+- Uses the signed-in user's saved workout sequence when available, whether it came from a pre-built program or the custom builder; otherwise falls back to the built-in default sequence
+- **Done!** — logs the workout and advances the sequence
 - **Log activity** — opens a chooser modal with all 5 workout types, Rest Day, and a freeform Other activity option
-- **Undo** — reverses the most recent log entry; rolls back the rotation if applicable
-- **Tomorrow preview** — shows the next step in the rotation below the card
+- **Undo** — reverses the most recent log entry; rolls back the sequence if applicable
+- **Tomorrow preview** — shows the next step in the workout sequence below the card
 
 **Journal card**
 - Incomplete state: "Journal" button opens the journal modal
@@ -73,22 +73,23 @@ The Today tab is a daily habit dashboard with customizable cards. All entry happ
 ### Log tab
 - **Calendar** (default): monthly grid with prev/next month navigation; each day shows a purple workout icon for completed workouts, an amber moon for rest/skip days, a teal zap icon for other activities, a dimmed projected icon for future days, or is empty for past days with no data; days with a journal entry show a small **green dot**; days with weight logged show a small **coral dot**; today is subtly highlighted; all past days are tappable
 - **List**: chronological log of all past entries (newest first), with workout icon, date, day of week, and name
-- **Schedule**: the next 14 projected workouts based on the current user rotation
-- **Past-day detail / backfill** — tap any past day in the calendar to open a day-detail sheet; it always opens in read-only mode first and shows exercise, weight, and any journal entry for that day; from there you can add or edit exercise, and add or edit weight for any past day; journal remains read-only; exercise options are all 5 rotation workouts, Rest Day, and Other Activity
+- **Schedule**: the next 14 projected workouts based on the current user sequence
+- **Past-day detail / backfill** — tap any past day in the calendar to open a day-detail sheet; it always opens in read-only mode first and shows exercise, weight, and any journal entry for that day; from there you can add or edit exercise, and add or edit weight for any past day; journal remains read-only; exercise options are all 5 sequence workouts, Rest Day, and Other Activity
 
 ### Stats tab
 - **Last 30 Days / All Time toggle** — defaults to Last 30 Days; toggle state resets on each open
 - **Weight Trend** — first section on the tab; shows raw weigh-in dots, a 7-day rolling average line, and a dimmer trendline; if fewer than 2 weights exist it shows an empty state instead
-- **Total Workouts** — count of rotation-advancing entries in the selected time range
+- **Total Workouts** — count of sequence-advancing entries in the selected time range
 - **Streaks** — current streak and longest streak (always computed from full history regardless of range toggle)
 - **Consistency %** — days with a workout / total days in range
 - **Workouts by Type** — horizontal progress bars for all 5 workout types
 
 ### Other
 - Offline-capable PWA, installable on iPhone home screen; entries logged while offline are automatically synced to Supabase the next time the app loads with a connection
-- **Account + Settings** — Settings shows the signed-in email, avatar initial, optional first/last name fields stored in Supabase auth metadata, Today Tab card toggles, a My Rotation area with reset-to-program and custom-builder flows, a Tutorial shortcut, Sync data now, Change password, Send feedback, Sign out, and a Danger Zone delete-account flow
+- **Account + Settings** — Settings shows the signed-in email, avatar initial, optional first/last name fields stored in Supabase auth metadata, Today Tab card toggles, a My Workout Sequence area with reset-to-program and custom-builder flows, a Tutorial shortcut, Sync data now, Change password, Send feedback, Sign out, and a Danger Zone delete-account flow
 - **Auth recovery** — login includes a Forgot password link that sends a Supabase password reset email; recovery links open the app and prompt for a new password
-- **First-time welcome screen** — brand-new signups see a one-time welcome overlay before the Today tab, with a quick walkthrough of workouts, journaling, weight tracking, and settings; dismiss state is stored per user in localStorage
+- **Direct signup link** — visiting `https://habits.chrisaug.com?signup=true` opens the signup form by default for unauthenticated users
+- **First-time onboarding** — brand-new signups see a one-time 6-screen onboarding flow before the Today tab. It explains the app's purpose, explains how workout sequences work, reuses the live starting-sequence picker, covers journaling and weight tracking, and ends with a final "Get started" step. Dismiss state is stored per user in localStorage, and the same flow stays available from Settings → Tutorial
 - **Test mode** — hidden feature; triple-tap the version stamp (bottom of Today screen) or press Alt+Shift+T to toggle; shows an amber banner confirming no real data is affected; uses isolated localStorage keys (`habits_test`, `habits_test_other_activities`, `habits_test_journal`) and skips all Supabase calls
 - **Sync status** — the version stamp at the bottom of the Today screen shows `synced just now` / `synced Xm ago` / `offline`; updates after every successful or failed Supabase read/write
 

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.24';
+    const VERSION = '1.5.25';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';

--- a/auth.js
+++ b/auth.js
@@ -15,6 +15,10 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     utils.showToast('Could not connect to the server');
   }
 
+  function shouldShowSignupByDefault() {
+    return !state.currentUser && new URLSearchParams(window.location.search).get('signup') === 'true';
+  }
+
   async function sendPasswordReset() {
     const errorEl = document.getElementById('login-error');
     if (!state.sb) {
@@ -70,14 +74,14 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     document.getElementById('password-modal').hidden = true;
     document.getElementById('delete-account-modal').hidden = true;
     document.getElementById('welcome-screen').hidden = true;
-    document.getElementById('program-picker-screen').hidden = true;
     document.getElementById('program-reset-modal').hidden = true;
     document.getElementById('program-reset-confirm-modal').hidden = true;
     document.getElementById('app-container').inert = false;
     document.getElementById('bottom-nav').inert = false;
     state.lastFocusedBeforeWelcome = null;
-    document.getElementById('login-panel').hidden = false;
-    document.getElementById('signup-panel').hidden = true;
+    const showSignup = shouldShowSignupByDefault();
+    document.getElementById('login-panel').hidden = showSignup;
+    document.getElementById('signup-panel').hidden = !showSignup;
   }
 
   function resolveInitialAuth(nextScreen) {
@@ -130,9 +134,7 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     await data.loadUserPreferences();
     deps.renderSettingsTodayTab();
     await deps.render();
-    if (deps.hasPendingWelcome() && !utils.hasCustomRotation()) {
-      deps.openProgramPickerScreen();
-    } else if (deps.hasPendingWelcome() && !deps.hasDismissedWelcome()) {
+    if (deps.hasPendingWelcome() && !deps.hasDismissedWelcome()) {
       deps.openWelcomeScreen();
     }
     deps.loadJournal().then(() => {

--- a/data.js
+++ b/data.js
@@ -409,7 +409,7 @@ window.HabitsApp.registerDataModule = function registerDataModule(ctx) {
     const orderedIds = Array.isArray(rotationArray)
       ? rotationArray.filter(id => typeof id === 'string' && id)
       : [];
-    if (orderedIds.length < 2) throw new Error('Rotation must contain at least 2 workouts');
+    if (orderedIds.length < 2) throw new Error('Workout sequence must contain at least 2 workouts');
 
     const nextRotation = orderedIds
       .map((id, index) => {
@@ -425,7 +425,7 @@ window.HabitsApp.registerDataModule = function registerDataModule(ctx) {
       })
       .filter(Boolean);
     if (nextRotation.length !== orderedIds.length) {
-      throw new Error('Could not resolve all workouts in the rotation');
+      throw new Error('Could not resolve all workouts in the sequence');
     }
 
     if (TEST_MODE) {
@@ -445,7 +445,7 @@ window.HabitsApp.registerDataModule = function registerDataModule(ctx) {
       return state.userRotation;
     } catch (err) {
       console.error('[user-rotation] save failed:', err);
-      deps.showToast?.('Could not save rotation');
+      deps.showToast?.('Could not save sequence');
       throw err;
     }
   }

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       <h1 class="auth-app-name">Habits</h1>
       <p class="auth-description">A personal daily habits tracker for workouts, weight logging, and daily journaling.</p>
       <ul class="auth-features">
-        <li>Smart workout rotation that tells you what to do each day</li>
+        <li>Smart workout sequence that tells you what to do each day</li>
         <li>Daily weight tracking with trend chart</li>
         <li>Morning journal for intention, gratitude, and focus</li>
       </ul>
@@ -88,70 +88,135 @@
   </div>
 
   <div id="welcome-screen" hidden role="dialog" aria-modal="true" aria-labelledby="welcome-title">
-    <div class="welcome-card">
-      <div class="welcome-badge">
-        <i data-lucide="sparkles"></i>
-        Welcome
-      </div>
-      <h2 class="welcome-title" id="welcome-title">Welcome to Habits</h2>
-      <div class="welcome-section">
-        <p class="welcome-copy">Habits is a simple daily tracker built around three things:
-tracking workouts (with suggestions!), tracking your weight (optionally), and completing your morning journal for better mindfulness.</p>
-      </div>
-      <div class="welcome-section">
-        <div class="welcome-section-head">
-          <i data-lucide="repeat"></i>
-          <span>Your workout rotation</span>
+    <div class="welcome-card onboarding-card">
+      <div class="onboarding-progress-row">
+        <div class="welcome-badge" id="onboarding-badge">
+          <i data-lucide="trending-up" id="onboarding-badge-icon"></i>
+          <span id="onboarding-badge-label">Step 1</span>
         </div>
-        <p class="welcome-copy">The app suggests workouts each day based on your workout rotation. New accounts start by picking a pre-built program or building a custom rotation from scratch, and you can reset or customize that setup anytime in Settings.</p>
-      </div>
-      <div class="welcome-section">
-        <div class="welcome-section-head">
-          <i data-lucide="book-open"></i>
-          <span>Daily journal</span>
+        <div class="onboarding-progress">
+          <div class="onboarding-progress-text" id="onboarding-progress-text">1 / 6</div>
+          <div class="onboarding-dots" aria-hidden="true">
+            <span class="onboarding-dot is-active"></span>
+            <span class="onboarding-dot"></span>
+            <span class="onboarding-dot"></span>
+            <span class="onboarding-dot"></span>
+            <span class="onboarding-dot"></span>
+            <span class="onboarding-dot"></span>
+          </div>
         </div>
-        <p class="welcome-copy">Each day has a short journal with three prompts: your intention for
-the day, something you're grateful for, and one thing you want to
-focus on. Takes about 60 seconds and helps ground you in being mindful and present each day.</p>
       </div>
-      <div class="welcome-section">
-        <div class="welcome-section-head">
-          <i data-lucide="scale"></i>
-          <span>Weight tracking</span>
+      <div class="onboarding-hero">
+        <div class="onboarding-hero-icon" id="onboarding-hero-icon">
+          <i data-lucide="trending-up"></i>
         </div>
-        <p class="welcome-copy">Log your weight each morning from the Today tab. Whether your goal is losing, gaining or maintaining, tracking your weight regularly helps achieve results! Over time you'll see a trend chart on the Stats tab showing your progress.</p>
       </div>
-      <div class="welcome-section">
-        <div class="welcome-section-head">
-          <i data-lucide="settings"></i>
-          <span>Settings</span>
-        </div>
-        <p class="welcome-copy">Use the Settings panel to manage your account details, reset or customize your workout rotation, and choose which Today tab cards you want to see for workouts, journaling, and weight. You can also change your password, send feedback, reopen this tutorial, sync data, or sign out.</p>
-      </div>
-      <button class="welcome-cta" id="welcome-continue-btn">
-        <span>Got it, let's go</span>
-        <i data-lucide="arrow-right"></i>
-      </button>
-    </div>
-  </div>
 
-  <div id="program-picker-screen" hidden role="dialog" aria-modal="true" aria-labelledby="program-picker-title">
-    <div class="welcome-card program-picker-screen-card">
-      <div class="welcome-badge">
-        <i data-lucide="repeat"></i>
-        Starting Rotation
-      </div>
-      <h2 class="welcome-title" id="program-picker-title">Choose a starting rotation</h2>
-      <p class="welcome-copy">Pick a program to get started. You can customize it anytime.</p>
-      <div class="program-picker-list" id="program-picker-screen-list"></div>
-      <button class="program-picker-custom-btn" id="program-picker-custom-btn" type="button">
-        <span>Build my own from scratch</span>
-        <i data-lucide="chevron-right"></i>
-      </button>
-      <button class="welcome-cta" id="program-picker-confirm-btn" type="button">
-        <span>Start with Balanced</span>
-        <i data-lucide="arrow-right"></i>
-      </button>
+      <section class="welcome-step" data-onboarding-step="1" data-badge-icon="trending-up" data-badge-label="Why Habits" data-hero-icon="trending-up">
+        <h2 class="welcome-title" id="welcome-title">Small actions. Big change.</h2>
+        <div class="welcome-section">
+          <p class="welcome-copy">The science is clear: consistency beats intensity every time. A short workout today is worth more than a perfect workout someday. Habits sets you up with a workout sequence and helps you stay on track — day by day, at your own pace.</p>
+        </div>
+        <div class="modal-actions welcome-actions">
+          <button class="welcome-cta" type="button" data-onboarding-next="2">
+            <span>Next</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
+
+      <section class="welcome-step" data-onboarding-step="2" data-badge-icon="repeat" data-badge-label="How It Works" data-hero-icon="repeat" hidden>
+        <h2 class="welcome-title">Your sequence. Your pace.</h2>
+        <div class="welcome-section">
+          <p class="welcome-copy">Habits gives you a personalized workout sequence — an ordered list of workouts that cycles day by day. Finish one, the next is waiting. Miss a day? No problem. Your sequence picks up exactly where you left off.</p>
+          <p class="welcome-copy">No fixed days. No guilt. Just your next step, always ready.</p>
+        </div>
+        <div class="modal-actions welcome-actions welcome-actions--split">
+          <button class="modal-cancel-btn" type="button" data-onboarding-back="1">Back</button>
+          <button class="welcome-cta" type="button" data-onboarding-next="3">
+            <span>Next</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
+
+      <section class="welcome-step" data-onboarding-step="3" data-badge-icon="list-ordered" data-badge-label="Pick A Sequence" data-hero-icon="list-ordered" hidden>
+        <h2 class="welcome-title" id="program-picker-title">Choose your starting point.</h2>
+        <p class="welcome-copy">Pick a pre-built sequence or build your own. You can customize it anytime from Settings.</p>
+        <div class="program-picker-list" id="program-picker-screen-list"></div>
+        <button class="program-picker-custom-btn" id="program-picker-custom-btn" type="button">
+          <span>Build my own from scratch</span>
+          <i data-lucide="chevron-right"></i>
+        </button>
+        <div class="modal-actions welcome-actions welcome-actions--split">
+          <button class="modal-cancel-btn" type="button" data-onboarding-back="2">Back</button>
+          <button class="welcome-cta" id="program-picker-confirm-btn" type="button">
+            <span>Start with Balanced</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
+
+      <section class="welcome-step" data-onboarding-step="4" data-badge-icon="book-open" data-badge-label="Journaling" data-hero-icon="book-open" hidden>
+        <h2 class="welcome-title">Three questions. Sixty seconds.</h2>
+        <div class="welcome-section">
+          <p class="welcome-copy">Research shows that writing down your intentions and gratitude — even briefly — meaningfully improves follow-through and wellbeing. Every day, Habits asks you three things:</p>
+        </div>
+        <div class="welcome-section">
+          <div class="welcome-section-head"><span>Intention</span></div>
+          <p class="welcome-copy">Who do you want to be today? Before the noise of the day takes over, intention asks you to pause and be deliberate. Not just what you'll do — but how you'll show up. Mindful. Present. Aligned with the person you're working to become.</p>
+        </div>
+        <div class="welcome-section">
+          <div class="welcome-section-head"><span>Gratitude</span></div>
+          <p class="welcome-copy">What are you grateful for? It's easy to fixate on what went wrong or what's still undone. Gratitude practice pushes back. When you stop to name something you're grateful for — even something small you usually take for granted — you start to see how much you've actually built. A hard day looks different when you can also name what's going right.</p>
+        </div>
+        <div class="welcome-section">
+          <div class="welcome-section-head"><span>One thing</span></div>
+          <p class="welcome-copy">What's the single most important thing you'll accomplish today? Your to-do list is probably long and will never be fully done — that's normal. This isn't about shrinking your ambitions. It's about being intentional. If you only clear one item today, which one would make everything else feel worth it?</p>
+        </div>
+        <div class="welcome-section">
+          <p class="welcome-copy">Sixty seconds. Compounding returns.</p>
+          <p class="welcome-copy"><em>Not feeling journaling every day? You can turn it off in Settings.</em></p>
+        </div>
+        <div class="modal-actions welcome-actions welcome-actions--split">
+          <button class="modal-cancel-btn" type="button" data-onboarding-back="3">Back</button>
+          <button class="welcome-cta" type="button" data-onboarding-next="5">
+            <span>Next</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
+
+      <section class="welcome-step" data-onboarding-step="5" data-badge-icon="activity" data-badge-label="Weight Tracking" data-hero-icon="activity" hidden>
+        <h2 class="welcome-title">Daily tracking reveals what sporadic weigh-ins hide.</h2>
+        <div class="welcome-section">
+          <p class="welcome-copy">Your weight fluctuates by 2–4 lbs every single day based on water, food, sleep, and stress. A single weigh-in can mislead you — whether you're losing, gaining, or maintaining. Catch yourself on a rough day and you feel like you're failing; catch a favorable day and you feel like you've arrived. Neither is the full picture.</p>
+          <p class="welcome-copy">Daily tracking gives you the truth. Habits shows your weight trend over time and your 7-day rolling average — the signal, not the noise. That's the number worth paying attention to, whatever direction you're headed.</p>
+          <p class="welcome-copy"><em>Not ready to track weight yet? You can turn it off in Settings.</em></p>
+        </div>
+        <div class="modal-actions welcome-actions welcome-actions--split">
+          <button class="modal-cancel-btn" type="button" data-onboarding-back="4">Back</button>
+          <button class="welcome-cta" type="button" data-onboarding-next="6">
+            <span>Next</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
+
+      <section class="welcome-step" data-onboarding-step="6" data-badge-icon="check-circle" data-badge-label="Ready" data-hero-icon="check-circle" hidden>
+        <h2 class="welcome-title">You're all set.</h2>
+        <div class="welcome-section">
+          <p class="welcome-copy">Your sequence is loaded. Your habits are waiting. Let's go.</p>
+          <p class="welcome-copy">Not ready to track everything at once? That's completely fine. Head to Settings to choose which habits are right for you — workouts, journaling, and weight tracking can each be turned on or off independently.</p>
+        </div>
+        <div class="modal-actions welcome-actions welcome-actions--split">
+          <button class="modal-cancel-btn" type="button" data-onboarding-back="5">Back</button>
+          <button class="welcome-cta" id="welcome-continue-btn" type="button">
+            <span>Get started</span>
+            <i data-lucide="arrow-right"></i>
+          </button>
+        </div>
+      </section>
     </div>
   </div>
 
@@ -292,14 +357,14 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
         </div>
       </div>
       <div class="settings-section">
-        <div class="settings-section-title">My Workout Rotation</div>
+        <div class="settings-section-title">My Workout Sequence</div>
         <div class="settings-card" id="settings-rotation-card">
           <div class="settings-rotation-empty" id="settings-rotation-empty" hidden>
-            <div class="settings-rotation-empty-title">Using default rotation</div>
+            <div class="settings-rotation-empty-title">Using default sequence</div>
             <div class="settings-rotation-empty-note">Build your own workout order and save it to your account.</div>
           </div>
           <div class="settings-rotation-list" id="settings-rotation-list" hidden></div>
-          <button class="settings-secondary-btn" id="rotation-builder-open-btn">Customize my workout rotation</button>
+          <button class="settings-secondary-btn" id="rotation-builder-open-btn">Customize my workout sequence</button>
           <button class="settings-secondary-btn" id="reset-program-btn" type="button">
             <i data-lucide="rotate-ccw"></i>
             Reset to a program
@@ -504,7 +569,7 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
         <button class="rotation-builder-close-btn" id="rotation-builder-close-btn" type="button" aria-label="Close">
           <i data-lucide="x"></i>
         </button>
-        <div class="modal-title rotation-builder-title" id="rotation-builder-title">My Workout Rotation</div>
+        <div class="modal-title rotation-builder-title" id="rotation-builder-title">My Workout Sequence</div>
         <div class="rotation-builder-spacer" aria-hidden="true"></div>
       </div>
 
@@ -512,8 +577,8 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
         <section class="rotation-builder-section">
           <div class="rotation-builder-section-head">
             <div>
-              <div class="rotation-builder-section-title">Current rotation</div>
-              <div class="rotation-builder-section-note">Keep at least 2 workouts in your rotation.</div>
+              <div class="rotation-builder-section-title">Current sequence</div>
+              <div class="rotation-builder-section-note">Keep at least 2 workouts in your sequence.</div>
             </div>
           </div>
           <div class="rotation-builder-current-list" id="rotation-builder-current-list"></div>
@@ -565,7 +630,7 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
 
       <div class="modal-actions rotation-builder-actions">
         <button class="modal-cancel-btn" id="rotation-builder-cancel-btn" type="button">Cancel</button>
-        <button class="modal-confirm-btn" id="rotation-builder-save-btn" type="button">Save rotation</button>
+        <button class="modal-confirm-btn" id="rotation-builder-save-btn" type="button">Save sequence</button>
       </div>
     </div>
   </div>
@@ -573,7 +638,7 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
   <div class="modal-overlay" id="program-reset-modal" hidden role="dialog" aria-modal="true" aria-labelledby="program-reset-title">
     <div class="modal-sheet">
       <div class="modal-title" id="program-reset-title">Choose a program</div>
-      <div class="program-picker-sheet-copy">Pick a saved program to replace your current rotation.</div>
+      <div class="program-picker-sheet-copy">Pick a saved program to replace your current sequence.</div>
       <div class="program-picker-list program-picker-list--sheet" id="program-reset-list"></div>
       <button class="program-picker-custom-btn program-picker-custom-btn--sheet" id="program-reset-custom-btn" type="button">
         <span>Build my own from scratch</span>
@@ -585,7 +650,7 @@ focus on. Takes about 60 seconds and helps ground you in being mindful and prese
 
   <div class="modal-overlay" id="program-reset-confirm-modal" hidden role="dialog" aria-modal="true" aria-labelledby="program-reset-confirm-title">
     <div class="modal-sheet">
-      <div class="modal-title" id="program-reset-confirm-title">Replace your current rotation?</div>
+      <div class="modal-title" id="program-reset-confirm-title">Replace your current sequence?</div>
       <div class="program-picker-confirm-copy" id="program-reset-confirm-copy">This cannot be undone.</div>
       <div class="modal-actions">
         <button class="modal-cancel-btn" id="program-reset-confirm-cancel-btn" type="button">Cancel</button>

--- a/index.html
+++ b/index.html
@@ -106,13 +106,7 @@
           </div>
         </div>
       </div>
-      <div class="onboarding-hero">
-        <div class="onboarding-hero-icon" id="onboarding-hero-icon">
-          <i data-lucide="trending-up"></i>
-        </div>
-      </div>
-
-      <section class="welcome-step" data-onboarding-step="1" data-badge-icon="trending-up" data-badge-label="Why Habits" data-hero-icon="trending-up">
+      <section class="welcome-step" data-onboarding-step="1" data-badge-icon="trending-up" data-badge-label="Why Habits">
         <h2 class="welcome-title" id="welcome-title">Small actions. Big change.</h2>
         <div class="welcome-section">
           <p class="welcome-copy">The science is clear: consistency beats intensity every time. A short workout today is worth more than a perfect workout someday. Habits sets you up with a workout sequence and helps you stay on track — day by day, at your own pace.</p>
@@ -125,7 +119,7 @@
         </div>
       </section>
 
-      <section class="welcome-step" data-onboarding-step="2" data-badge-icon="repeat" data-badge-label="How It Works" data-hero-icon="repeat" hidden>
+      <section class="welcome-step" data-onboarding-step="2" data-badge-icon="repeat" data-badge-label="How It Works" hidden>
         <h2 class="welcome-title">Your sequence. Your pace.</h2>
         <div class="welcome-section">
           <p class="welcome-copy">Habits gives you a personalized workout sequence — an ordered list of workouts that cycles day by day. Finish one, the next is waiting. Miss a day? No problem. Your sequence picks up exactly where you left off.</p>
@@ -140,7 +134,7 @@
         </div>
       </section>
 
-      <section class="welcome-step" data-onboarding-step="3" data-badge-icon="list-ordered" data-badge-label="Pick A Sequence" data-hero-icon="list-ordered" hidden>
+      <section class="welcome-step" data-onboarding-step="3" data-badge-icon="list-ordered" data-badge-label="Pick A Sequence" hidden>
         <h2 class="welcome-title" id="program-picker-title">Choose your starting point.</h2>
         <p class="welcome-copy">Pick a pre-built sequence or build your own. You can customize it anytime from Settings.</p>
         <div class="program-picker-list" id="program-picker-screen-list"></div>
@@ -157,7 +151,7 @@
         </div>
       </section>
 
-      <section class="welcome-step" data-onboarding-step="4" data-badge-icon="book-open" data-badge-label="Journaling" data-hero-icon="book-open" hidden>
+      <section class="welcome-step" data-onboarding-step="4" data-badge-icon="book-open" data-badge-label="Journaling" hidden>
         <h2 class="welcome-title">Three questions. Sixty seconds.</h2>
         <div class="welcome-section">
           <p class="welcome-copy">Research shows that writing down your intentions and gratitude — even briefly — meaningfully improves follow-through and wellbeing. Every day, Habits asks you three things:</p>
@@ -187,7 +181,7 @@
         </div>
       </section>
 
-      <section class="welcome-step" data-onboarding-step="5" data-badge-icon="activity" data-badge-label="Weight Tracking" data-hero-icon="activity" hidden>
+      <section class="welcome-step" data-onboarding-step="5" data-badge-icon="activity" data-badge-label="Weight Tracking" hidden>
         <h2 class="welcome-title">Daily tracking reveals what sporadic weigh-ins hide.</h2>
         <div class="welcome-section">
           <p class="welcome-copy">Your weight fluctuates by 2–4 lbs every single day based on water, food, sleep, and stress. A single weigh-in can mislead you — whether you're losing, gaining, or maintaining. Catch yourself on a rough day and you feel like you're failing; catch a favorable day and you feel like you've arrived. Neither is the full picture.</p>
@@ -203,7 +197,7 @@
         </div>
       </section>
 
-      <section class="welcome-step" data-onboarding-step="6" data-badge-icon="check-circle" data-badge-label="Ready" data-hero-icon="check-circle" hidden>
+      <section class="welcome-step" data-onboarding-step="6" data-badge-icon="check-circle" data-badge-label="Ready" hidden>
         <h2 class="welcome-title">You're all set.</h2>
         <div class="welcome-section">
           <p class="welcome-copy">Your sequence is loaded. Your habits are waiting. Let's go.</p>

--- a/settings.js
+++ b/settings.js
@@ -20,6 +20,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
   let programPickerSaving = false;
   let onboardingStep = 1;
   const TOTAL_ONBOARDING_STEPS = 6;
+  let onboardingMode = 'first-run';
 
   function renderSettingsTodayTab() {
     document.getElementById('toggle-workout-card').checked = !!state.userPreferences.show_workout_card;
@@ -169,10 +170,26 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     if (typeof lucide !== 'undefined') lucide.createIcons();
   }
 
+  function getOnboardingVisibleSteps() {
+    return onboardingMode === 'tutorial'
+      ? [1, 2, 4, 5, 6]
+      : [1, 2, 3, 4, 5, 6];
+  }
+
+  function resolveOnboardingTarget(targetStep, direction) {
+    if (onboardingMode !== 'tutorial') return targetStep;
+    if (targetStep !== 3) return targetStep;
+    return direction === 'back' ? 2 : 4;
+  }
+
   function renderOnboardingStep() {
     const screen = document.getElementById('welcome-screen');
     const steps = [...screen.querySelectorAll('[data-onboarding-step]')];
-    const resolvedStep = Math.min(Math.max(onboardingStep, 1), TOTAL_ONBOARDING_STEPS);
+    const visibleSteps = getOnboardingVisibleSteps();
+    const fallbackStep = visibleSteps[0];
+    const requestedStep = Math.min(Math.max(onboardingStep, 1), TOTAL_ONBOARDING_STEPS);
+    const resolvedStep = visibleSteps.includes(requestedStep) ? requestedStep : fallbackStep;
+    const visibleStepIndex = visibleSteps.indexOf(resolvedStep);
     onboardingStep = resolvedStep;
 
     let activeStepEl = null;
@@ -188,14 +205,15 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     });
     if (!activeStepEl) return;
 
-    document.getElementById('onboarding-progress-text').textContent = `${resolvedStep} / ${TOTAL_ONBOARDING_STEPS}`;
+    document.getElementById('onboarding-progress-text').textContent = `${visibleStepIndex + 1} / ${visibleSteps.length}`;
     document.querySelectorAll('.onboarding-dot').forEach((dot, index) => {
-      dot.classList.toggle('is-active', index === resolvedStep - 1);
+      const isVisible = index < visibleSteps.length;
+      dot.hidden = !isVisible;
+      dot.classList.toggle('is-active', isVisible && index === visibleStepIndex);
     });
 
     document.getElementById('onboarding-badge-label').textContent = activeStepEl.dataset.badgeLabel || `Step ${resolvedStep}`;
     document.getElementById('onboarding-badge-icon').setAttribute('data-lucide', activeStepEl.dataset.badgeIcon || 'sparkles');
-    document.getElementById('onboarding-hero-icon').innerHTML = `<i data-lucide="${activeStepEl.dataset.heroIcon || 'sparkles'}"></i>`;
 
     if (resolvedStep === 3) {
       renderProgramPickerScreen();
@@ -234,6 +252,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
 
     if (!preserveStep) {
       onboardingStep = 1;
+      onboardingMode = 'first-run';
       if (state.lastFocusedBeforeWelcome && typeof state.lastFocusedBeforeWelcome.focus === 'function') {
         state.lastFocusedBeforeWelcome.focus();
       }
@@ -244,7 +263,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
   function openProgramPickerScreen() {
     programPickerFlow = 'ftux';
     selectedProgramId = getDefaultProgramId();
-    openWelcomeScreen(3);
+    openWelcomeScreen(3, { mode: 'first-run' });
   }
 
   function closeProgramPickerScreen(options = {}) {
@@ -613,11 +632,13 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     deps.setProfileEditing(!deps.hasSavedProfileName(meta));
   }
 
-  function openWelcomeScreen(startStep = 1) {
+  function openWelcomeScreen(startStep = 1, options = {}) {
+    const { mode = onboardingMode } = options;
     const screen = document.getElementById('welcome-screen');
     if (screen.hidden && !state.lastFocusedBeforeWelcome) {
       state.lastFocusedBeforeWelcome = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     }
+    onboardingMode = mode;
     screen.hidden = false;
     document.getElementById('app-container').inert = true;
     document.getElementById('bottom-nav').inert = true;
@@ -839,16 +860,16 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
 
   function bindEvents() {
     document.getElementById('welcome-continue-btn').onclick = () => closeWelcomeScreen();
-    document.getElementById('tutorial-btn').onclick = () => openWelcomeScreen(1);
+    document.getElementById('tutorial-btn').onclick = () => openWelcomeScreen(1, { mode: 'tutorial' });
     document.getElementById('welcome-screen').addEventListener('click', e => {
       const nextBtn = e.target.closest('[data-onboarding-next]');
       if (nextBtn) {
-        setOnboardingStep(Number(nextBtn.dataset.onboardingNext), { focusPrimary: true });
+        setOnboardingStep(resolveOnboardingTarget(Number(nextBtn.dataset.onboardingNext), 'next'), { focusPrimary: true });
         return;
       }
       const backBtn = e.target.closest('[data-onboarding-back]');
       if (backBtn) {
-        setOnboardingStep(Number(backBtn.dataset.onboardingBack), { focusPrimary: true });
+        setOnboardingStep(resolveOnboardingTarget(Number(backBtn.dataset.onboardingBack), 'back'), { focusPrimary: true });
       }
     });
 

--- a/settings.js
+++ b/settings.js
@@ -18,6 +18,8 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
   let pendingProgramResetId = null;
   let builderReturnToProgramPicker = false;
   let programPickerSaving = false;
+  let onboardingStep = 1;
+  const TOTAL_ONBOARDING_STEPS = 6;
 
   function renderSettingsTodayTab() {
     document.getElementById('toggle-workout-card').checked = !!state.userPreferences.show_workout_card;
@@ -167,28 +169,87 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     if (typeof lucide !== 'undefined') lucide.createIcons();
   }
 
-  function openProgramPickerScreen() {
-    programPickerFlow = 'ftux';
-    selectedProgramId = getDefaultProgramId();
-    renderProgramPickerScreen();
-    const screen = document.getElementById('program-picker-screen');
-    screen.hidden = false;
-    document.getElementById('app-container').inert = true;
-    document.getElementById('bottom-nav').inert = true;
+  function renderOnboardingStep() {
+    const screen = document.getElementById('welcome-screen');
+    const steps = [...screen.querySelectorAll('[data-onboarding-step]')];
+    const resolvedStep = Math.min(Math.max(onboardingStep, 1), TOTAL_ONBOARDING_STEPS);
+    onboardingStep = resolvedStep;
+
+    let activeStepEl = null;
+    steps.forEach(stepEl => {
+      const isActive = Number(stepEl.dataset.onboardingStep) === resolvedStep;
+      stepEl.hidden = !isActive;
+      const titleEl = stepEl.querySelector('.welcome-title');
+      if (titleEl) {
+        if (isActive) titleEl.id = 'welcome-title';
+        else if (titleEl.id === 'welcome-title') titleEl.removeAttribute('id');
+      }
+      if (isActive) activeStepEl = stepEl;
+    });
+    if (!activeStepEl) return;
+
+    document.getElementById('onboarding-progress-text').textContent = `${resolvedStep} / ${TOTAL_ONBOARDING_STEPS}`;
+    document.querySelectorAll('.onboarding-dot').forEach((dot, index) => {
+      dot.classList.toggle('is-active', index === resolvedStep - 1);
+    });
+
+    document.getElementById('onboarding-badge-label').textContent = activeStepEl.dataset.badgeLabel || `Step ${resolvedStep}`;
+    document.getElementById('onboarding-badge-icon').setAttribute('data-lucide', activeStepEl.dataset.badgeIcon || 'sparkles');
+    document.getElementById('onboarding-hero-icon').innerHTML = `<i data-lucide="${activeStepEl.dataset.heroIcon || 'sparkles'}"></i>`;
+
+    if (resolvedStep === 3) {
+      renderProgramPickerScreen();
+    }
+
+    if (typeof lucide !== 'undefined') lucide.createIcons();
+  }
+
+  function setOnboardingStep(step, options = {}) {
+    const { focusPrimary = false } = options;
+    onboardingStep = Math.min(Math.max(step, 1), TOTAL_ONBOARDING_STEPS);
+    renderOnboardingStep();
+
+    const screen = document.getElementById('welcome-screen');
     requestAnimationFrame(() => {
       screen.scrollTop = 0;
-      const focusTarget = document.getElementById('program-picker-confirm-btn').disabled
-        ? document.getElementById('program-picker-custom-btn')
-        : document.getElementById('program-picker-confirm-btn');
+      if (!focusPrimary) return;
+      const activeStepEl = screen.querySelector(`[data-onboarding-step="${onboardingStep}"]`);
+      const focusTarget = activeStepEl?.querySelector(
+        '#program-picker-confirm-btn, #welcome-continue-btn, [data-onboarding-next], [data-onboarding-back]'
+      );
       focusTarget?.focus({ preventScroll: true });
     });
   }
 
-  function closeProgramPickerScreen(options = {}) {
-    const { preserveFlow = false } = options;
-    document.getElementById('program-picker-screen').hidden = true;
+  function hideOnboardingScreen(options = {}) {
+    const { preserveStep = false, markDismissed = false } = options;
+    const screen = document.getElementById('welcome-screen');
+    screen.hidden = true;
     document.getElementById('app-container').inert = false;
     document.getElementById('bottom-nav').inert = false;
+
+    if (markDismissed) {
+      deps.markWelcomeDismissed(state.currentUser?.id);
+    }
+
+    if (!preserveStep) {
+      onboardingStep = 1;
+      if (state.lastFocusedBeforeWelcome && typeof state.lastFocusedBeforeWelcome.focus === 'function') {
+        state.lastFocusedBeforeWelcome.focus();
+      }
+      state.lastFocusedBeforeWelcome = null;
+    }
+  }
+
+  function openProgramPickerScreen() {
+    programPickerFlow = 'ftux';
+    selectedProgramId = getDefaultProgramId();
+    openWelcomeScreen(3);
+  }
+
+  function closeProgramPickerScreen(options = {}) {
+    const { preserveFlow = false } = options;
+    hideOnboardingScreen({ preserveStep: preserveFlow });
     selectedProgramId = null;
     if (!preserveFlow) {
       programPickerFlow = null;
@@ -224,7 +285,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     const program = getProgramById(programId);
     if (!program) return;
     pendingProgramResetId = programId;
-    document.getElementById('program-reset-confirm-copy').textContent = `Replace your current rotation with ${program.name}? This cannot be undone.`;
+    document.getElementById('program-reset-confirm-copy').textContent = `Replace your current sequence with ${program.name}? This cannot be undone.`;
     document.getElementById('program-reset-confirm-btn').disabled = false;
     document.getElementById('program-reset-confirm-modal').hidden = false;
   }
@@ -235,11 +296,8 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
   }
 
   function finishFtuxProgramFlow() {
-    closeProgramPickerScreen();
     deps.switchMainTab('today');
-    if (deps.hasPendingWelcome() && !deps.hasDismissedWelcome()) {
-      deps.openWelcomeScreen();
-    }
+    openWelcomeScreen(4);
   }
 
   async function applyProgramSelection(programId, flow) {
@@ -259,21 +317,21 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
 
       if (flow === 'ftux') {
         finishFtuxProgramFlow();
-        utils.showToast('Starting rotation saved');
+        utils.showToast('Starting sequence saved');
       } else {
         closeProgramResetConfirm();
         closeProgramResetPicker();
-        utils.showToast('Rotation replaced');
+        utils.showToast('Sequence replaced');
       }
     } catch (err) {
       console.error('[program-picker] save failed:', err);
-      utils.showToast('Could not save rotation');
+      utils.showToast('Could not save sequence');
       if (flow === 'reset') {
         document.getElementById('program-reset-confirm-btn').disabled = false;
       }
     } finally {
       programPickerSaving = false;
-      if (flow === 'ftux' && !document.getElementById('program-picker-screen').hidden) {
+      if (flow === 'ftux' && !document.getElementById('welcome-screen').hidden && onboardingStep === 3) {
         renderProgramPickerScreen();
       } else if (flow === 'reset' && !document.getElementById('program-reset-modal').hidden) {
         renderProgramResetPicker();
@@ -302,7 +360,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
       emptyEl.hidden = false;
       listEl.hidden = true;
       listEl.innerHTML = '';
-      buttonEl.textContent = 'Customize my rotation';
+      buttonEl.textContent = 'Customize my sequence';
       return;
     }
 
@@ -319,7 +377,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
         </div>
       </div>
     `).join('');
-    buttonEl.textContent = 'Edit rotation';
+    buttonEl.textContent = 'Edit sequence';
     if (typeof lucide !== 'undefined') lucide.createIcons();
   }
 
@@ -461,13 +519,13 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
       await deps.render(state.cachedData);
       if (completesFtuxProgramFlow) {
         finishFtuxProgramFlow();
-        utils.showToast('Rotation saved');
+        utils.showToast('Sequence saved');
       } else {
-        utils.showToast('Rotation saved');
+        utils.showToast('Sequence saved');
       }
     } catch (err) {
       console.error('[rotation-builder] save failed:', err);
-      utils.showToast('Failed to save rotation — please try again');
+      utils.showToast('Failed to save sequence — please try again');
     } finally {
       rotationBuilderSaving = false;
       if (!document.getElementById('rotation-builder-modal').hidden) {
@@ -555,33 +613,19 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     deps.setProfileEditing(!deps.hasSavedProfileName(meta));
   }
 
-  function openWelcomeScreen() {
+  function openWelcomeScreen(startStep = 1) {
     const screen = document.getElementById('welcome-screen');
-    state.lastFocusedBeforeWelcome = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    if (screen.hidden && !state.lastFocusedBeforeWelcome) {
+      state.lastFocusedBeforeWelcome = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    }
     screen.hidden = false;
     document.getElementById('app-container').inert = true;
     document.getElementById('bottom-nav').inert = true;
-    if (typeof lucide !== 'undefined') lucide.createIcons();
-    requestAnimationFrame(() => {
-      screen.scrollTop = 0;
-      screen.scrollTo(0, 0);
-      const card = screen.querySelector('.welcome-card');
-      if (card) card.scrollIntoView({ block: 'start' });
-      const continueBtn = document.getElementById('welcome-continue-btn');
-      if (continueBtn) continueBtn.focus({ preventScroll: true });
-    });
+    setOnboardingStep(startStep, { focusPrimary: true });
   }
 
   function closeWelcomeScreen() {
-    deps.markWelcomeDismissed(state.currentUser?.id);
-    const screen = document.getElementById('welcome-screen');
-    screen.hidden = true;
-    document.getElementById('app-container').inert = false;
-    document.getElementById('bottom-nav').inert = false;
-    if (state.lastFocusedBeforeWelcome && typeof state.lastFocusedBeforeWelcome.focus === 'function') {
-      state.lastFocusedBeforeWelcome.focus();
-    }
-    state.lastFocusedBeforeWelcome = null;
+    hideOnboardingScreen({ markDismissed: true });
   }
 
   function openFeedbackModal() {
@@ -795,7 +839,18 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
 
   function bindEvents() {
     document.getElementById('welcome-continue-btn').onclick = () => closeWelcomeScreen();
-    document.getElementById('tutorial-btn').onclick = () => openWelcomeScreen();
+    document.getElementById('tutorial-btn').onclick = () => openWelcomeScreen(1);
+    document.getElementById('welcome-screen').addEventListener('click', e => {
+      const nextBtn = e.target.closest('[data-onboarding-next]');
+      if (nextBtn) {
+        setOnboardingStep(Number(nextBtn.dataset.onboardingNext), { focusPrimary: true });
+        return;
+      }
+      const backBtn = e.target.closest('[data-onboarding-back]');
+      if (backBtn) {
+        setOnboardingStep(Number(backBtn.dataset.onboardingBack), { focusPrimary: true });
+      }
+    });
 
     document.getElementById('save-profile-btn').onclick = () => saveProfile();
     document.getElementById('toggle-workout-card').addEventListener('change', e => {
@@ -829,7 +884,7 @@ window.HabitsApp.registerSettingsModule = function registerSettingsModule(ctx) {
     document.getElementById('rotation-builder-open-btn').onclick = () => openRotationBuilder();
     document.getElementById('program-picker-confirm-btn').onclick = () => confirmSelectedProgram();
     document.getElementById('program-picker-custom-btn').onclick = () => openCustomBuilderFromFtux();
-    document.getElementById('program-picker-screen').addEventListener('click', e => {
+    document.getElementById('program-picker-screen-list').addEventListener('click', e => {
       if (programPickerSaving) return;
       const card = e.target.closest('[data-program-id]');
       if (!card) return;

--- a/style.css
+++ b/style.css
@@ -621,6 +621,79 @@
       margin: 0 auto;
     }
 
+    .onboarding-card {
+      gap: 16px;
+    }
+
+    .onboarding-progress-row {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .onboarding-progress {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 8px;
+    }
+
+    .onboarding-progress-text {
+      color: var(--text-secondary);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .onboarding-dots {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .onboarding-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.14);
+      transition: transform 0.15s, background 0.15s;
+    }
+
+    .onboarding-dot.is-active {
+      background: var(--accent);
+      transform: scale(1.15);
+    }
+
+    .onboarding-hero {
+      display: flex;
+      justify-content: center;
+    }
+
+    .onboarding-hero-icon {
+      width: 68px;
+      height: 68px;
+      border-radius: 22px;
+      display: grid;
+      place-items: center;
+      background: rgba(108, 99, 255, 0.16);
+      color: #d4d0ff;
+      border: 1px solid rgba(108, 99, 255, 0.22);
+    }
+
+    .onboarding-hero-icon svg,
+    .onboarding-hero-icon i {
+      width: 30px;
+      height: 30px;
+    }
+
+    .welcome-step {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
     .welcome-badge {
       display: inline-flex;
       align-items: center;
@@ -680,6 +753,21 @@
       line-height: 1.6;
     }
 
+    .welcome-actions {
+      margin-top: 4px;
+    }
+
+    .welcome-actions--split {
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .welcome-actions--split .modal-cancel-btn,
+    .welcome-actions--split .welcome-cta {
+      width: 100%;
+    }
+
     .welcome-cta {
       display: flex;
       align-items: center;
@@ -703,22 +791,6 @@
     .welcome-cta:active {
       background: var(--accent-dark);
       transform: translateY(1px);
-    }
-
-    #program-picker-screen {
-      position: fixed;
-      inset: 0;
-      z-index: 330;
-      display: flex;
-      align-items: flex-start;
-      justify-content: center;
-      padding: calc(env(safe-area-inset-top, 0px) + 12px) 16px
-               calc(env(safe-area-inset-bottom, 0px) + 20px);
-      background:
-        radial-gradient(circle at top, rgba(108, 99, 255, 0.22), transparent 38%),
-        rgba(13, 13, 20, 0.92);
-      backdrop-filter: blur(10px);
-      overflow-y: auto;
     }
 
     .program-picker-screen-card {

--- a/style.css
+++ b/style.css
@@ -666,28 +666,6 @@
       transform: scale(1.15);
     }
 
-    .onboarding-hero {
-      display: flex;
-      justify-content: center;
-    }
-
-    .onboarding-hero-icon {
-      width: 68px;
-      height: 68px;
-      border-radius: 22px;
-      display: grid;
-      place-items: center;
-      background: rgba(108, 99, 255, 0.16);
-      color: #d4d0ff;
-      border: 1px solid rgba(108, 99, 255, 0.22);
-    }
-
-    .onboarding-hero-icon svg,
-    .onboarding-hero-icon i {
-      width: 30px;
-      height: 30px;
-    }
-
     .welcome-step {
       display: flex;
       flex-direction: column;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v24';
+const CACHE = 'habits-v25';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- replace user-facing workout rotation copy with workout sequence language across the app UI
- replace the old split FTUX flow with a single 6-step onboarding flow that reuses the live starting-sequence picker
- default the auth screen to signup for unauthenticated visits to ?signup=true and update docs/versioning

Closes #135

AI-assisted with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified 6-step onboarding used by FTUX and Tutorial with visual progress (counter/dots).
  * Direct signup via URL parameter and Tutorial accessible from Settings.
  * Custom sequence builder: cancel returns to onboarding step 3; successful save advances to step 4.

* **UI Updates**
  * Renamed "Workout Rotation" to "Workout Sequence" across copy and toasts.
  * Today/Log/Stats descriptions updated to reference sequence-based advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->