### PR TITLE
Fix mobile signup sticky CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.25**
+**Current version: 1.5.33**
 
 Live at: https://habits.chrisaug.com
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.33**
+**Current version: 1.5.34**
 
 Live at: https://habits.chrisaug.com
 

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.32';
+    const VERSION = '1.5.33';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.33';
+    const VERSION = '1.5.34';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';

--- a/auth.js
+++ b/auth.js
@@ -83,6 +83,51 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     }
   }
 
+  function disconnectSignupStickyObserver() {
+    if (state.signupStickyObserver) {
+      state.signupStickyObserver.disconnect();
+      state.signupStickyObserver = null;
+    }
+  }
+
+  function syncSignupStickyCta() {
+    const signupPanel = document.getElementById('signup-panel');
+    const inlineSignupBtn = document.getElementById('signup-btn');
+    const stickyWrap = document.getElementById('signup-sticky-cta-wrap');
+
+    if (!signupPanel || !inlineSignupBtn || !stickyWrap) return;
+
+    const isMobileViewport = window.matchMedia('(max-width: 768px)').matches;
+    const shouldHideSticky = signupPanel.hidden || !isMobileViewport;
+
+    if (shouldHideSticky) {
+      stickyWrap.classList.add('is-hidden');
+      disconnectSignupStickyObserver();
+      return;
+    }
+
+    if (!('IntersectionObserver' in window)) {
+      stickyWrap.classList.remove('is-hidden');
+      return;
+    }
+
+    stickyWrap.classList.remove('is-hidden');
+
+    if (state.signupStickyObserverTarget === inlineSignupBtn && state.signupStickyObserver) {
+      return;
+    }
+
+    disconnectSignupStickyObserver();
+    state.signupStickyObserverTarget = inlineSignupBtn;
+    state.signupStickyObserver = new window.IntersectionObserver((entries) => {
+      const [entry] = entries;
+      stickyWrap.classList.toggle('is-hidden', Boolean(entry?.isIntersecting));
+    }, {
+      threshold: 0.01,
+    });
+    state.signupStickyObserver.observe(inlineSignupBtn);
+  }
+
   async function sendPasswordReset() {
     const errorEl = document.getElementById('login-error');
     if (!state.sb) {
@@ -147,6 +192,7 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     document.getElementById('login-panel').hidden = showSignup;
     document.getElementById('signup-panel').hidden = !showSignup;
     if (showSignup) runSignupQuoteAnimation();
+    syncSignupStickyCta();
   }
 
   function resolveInitialAuth(nextScreen) {
@@ -226,10 +272,12 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
       document.getElementById('login-panel').hidden = true;
       document.getElementById('signup-panel').hidden = false;
       runSignupQuoteAnimation();
+      syncSignupStickyCta();
     };
     document.getElementById('show-login-btn').onclick = () => {
       document.getElementById('signup-panel').hidden = true;
       document.getElementById('login-panel').hidden = false;
+      syncSignupStickyCta();
     };
     document.getElementById('forgot-password-btn').onclick = () => sendPasswordReset();
     document.getElementById('signup-sticky-cta').onclick = () => scrollToSignupForm();
@@ -237,6 +285,8 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     if (!document.getElementById('signup-panel').hidden) {
       runSignupQuoteAnimation();
     }
+    syncSignupStickyCta();
+    window.addEventListener('resize', syncSignupStickyCta);
 
     ['login-email', 'login-password'].forEach(id => {
       document.getElementById(id).addEventListener('keydown', e => {

--- a/index.html
+++ b/index.html
@@ -113,7 +113,9 @@
           <button class="auth-link-btn" id="show-login-btn">Sign in</button>
         </p>
       </div>
-      <button class="auth-primary-btn signup-sticky-cta" id="signup-sticky-cta" type="button">Create account</button>
+      <div class="signup-sticky-cta-wrap" id="signup-sticky-cta-wrap">
+        <button class="auth-primary-btn signup-sticky-cta" id="signup-sticky-cta" type="button">Create account</button>
+      </div>
       <div class="auth-version-stamp" id="signup-version-stamp"></div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -3446,13 +3446,20 @@
         bottom: 0;
         padding-bottom: env(safe-area-inset-bottom, 0px);
         z-index: 340;
+        opacity: 1;
+        pointer-events: auto;
+        transition: opacity 240ms ease;
       }
 
       .signup-sticky-cta-wrap.is-hidden {
-        display: none;
+        opacity: 0;
+        pointer-events: none;
       }
 
       .signup-sticky-cta {
+        width: calc(100% - 40px);
+        margin-left: 20px;
+        margin-right: 20px;
         margin-top: 0;
         margin-bottom: 14px;
         box-shadow: 0 18px 44px rgba(91, 33, 182, 0.35);

--- a/style.css
+++ b/style.css
@@ -3308,8 +3308,12 @@
         0 18px 50px rgba(0, 0, 0, 0.24);
     }
 
-    .signup-sticky-cta {
+    .signup-sticky-cta-wrap {
       display: none;
+    }
+
+    .signup-sticky-cta {
+      margin-top: 0;
     }
 
     .auth-input {
@@ -3434,14 +3438,23 @@
         min-height: 5.3em;
       }
 
-      .signup-sticky-cta {
+      .signup-sticky-cta-wrap {
         display: block;
         position: fixed;
         left: 16px;
         right: 16px;
-        bottom: calc(env(safe-area-inset-bottom, 0px) + 14px);
+        bottom: 0;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
         z-index: 340;
+      }
+
+      .signup-sticky-cta-wrap.is-hidden {
+        display: none;
+      }
+
+      .signup-sticky-cta {
         margin-top: 0;
+        margin-bottom: 14px;
         box-shadow: 0 18px 44px rgba(91, 33, 182, 0.35);
       }
     }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v33';
+const CACHE = 'habits-v34';
 const PRECACHE = [
   '/',
   '/index.html',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v32';
+const CACHE = 'habits-v33';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- fix the mobile signup sticky CTA so it respects the iOS bottom safe area
- hide the sticky CTA when the inline `Create account` button is visible in the signup form
- bump the Habits app and service worker versions to `1.5.33` / `habits-v33`

## Why
The sticky mobile CTA on the Habits signup page had two regressions on iOS mobile: it could sit too low against the viewport bottom edge, and it stayed visible at the same time as the inline submit button once the form button entered view.

## Impact
This keeps the mobile signup experience clean and usable on iPhone without changing button copy, styling, or desktop behavior.

## Validation
- `node --check auth.js`
- manual code review of the mobile-only CSS and signup visibility logic

AI-assisted: Codex