### PR TITLE
Swap root and login routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.34**
+**Current version: 1.5.35**
 
 Live at: https://habits.chrisaug.com
 
@@ -87,8 +87,8 @@ The Today tab is a daily habit dashboard with customizable cards. All entry happ
 ### Other
 - Offline-capable PWA, installable on iPhone home screen; entries logged while offline are automatically synced to Supabase the next time the app loads with a connection
 - **Account + Settings** — Settings shows the signed-in email, avatar initial, optional first/last name fields stored in Supabase auth metadata, Today Tab card toggles, a My Workout Sequence area with reset-to-program and custom-builder flows, a Tutorial shortcut, Sync data now, Change password, Send feedback, Sign out, and a Danger Zone delete-account flow
-- **Auth recovery** — login includes a Forgot password link that sends a Supabase password reset email; recovery links open the app and prompt for a new password
-- **Direct signup link** — visiting `https://habits.chrisaug.com?signup=true` opens the signup form by default for unauthenticated users
+- **Auth recovery** — login at `https://habits.chrisaug.com/login` includes a Forgot password link that sends a Supabase password reset email; recovery links return to `/login` and prompt for a new password
+- **Public auth routes** — unauthenticated visitors land on the marketing/signup page at `https://habits.chrisaug.com/`, while the sparse sign-in screen lives at `https://habits.chrisaug.com/login`
 - **First-time onboarding** — brand-new signups see a one-time 6-screen onboarding flow before the Today tab. It explains the app's purpose, explains how workout sequences work, reuses the live starting-sequence picker, covers journaling and weight tracking, and ends with a final "Get started" step. Dismiss state is stored per user in localStorage, and the same flow stays available from Settings → Tutorial
 - **Test mode** — hidden feature; triple-tap the version stamp (bottom of Today screen) or press Alt+Shift+T to toggle; shows an amber banner confirming no real data is affected; uses isolated localStorage keys (`habits_test`, `habits_test_other_activities`, `habits_test_journal`) and skips all Supabase calls
 - **Sync status** — the version stamp at the bottom of the Today screen shows `synced just now` / `synced Xm ago` / `offline`; updates after every successful or failed Supabase read/write

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A mobile-first PWA for daily habits — workout tracking, journaling, and intention-setting.
 
-**Current version: 1.5.35**
+**Current version: 1.5.36**
 
 Live at: https://habits.chrisaug.com
 

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.34';
+    const VERSION = '1.5.35';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@
       'peloton', 'yoga',
     ];
 
-    const VERSION = '1.5.35';
+    const VERSION = '1.5.36';
 
     // ── Test mode ────────────────────────────────────────────────────────────
     const TEST_MODE = new URLSearchParams(window.location.search).get('test') === 'true';

--- a/auth.js
+++ b/auth.js
@@ -6,6 +6,7 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
   const utils = ctx.utils;
   const data = ctx.data;
   const deps = ctx.deps;
+  const LOGIN_PATH = '/login';
 
   function showConnectivityError(errorEl) {
     if (errorEl) {
@@ -16,7 +17,22 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
   }
 
   function shouldShowSignupByDefault() {
-    return !state.currentUser && new URLSearchParams(window.location.search).get('signup') === 'true';
+    return !state.currentUser && window.location.pathname !== LOGIN_PATH;
+  }
+
+  function setAuthRoute(route, { replace = false } = {}) {
+    const pathname = route === 'login' ? LOGIN_PATH : '/';
+    const nextUrl = `${pathname}${window.location.search}${window.location.hash}`;
+    if (`${window.location.pathname}${window.location.search}${window.location.hash}` === nextUrl) return;
+    window.history[replace ? 'replaceState' : 'pushState']({}, '', nextUrl);
+  }
+
+  function syncAuthPanelsToRoute() {
+    const showSignup = shouldShowSignupByDefault();
+    document.getElementById('login-panel').hidden = showSignup;
+    document.getElementById('signup-panel').hidden = !showSignup;
+    if (showSignup) runSignupQuoteAnimation();
+    syncSignupStickyCta();
   }
 
   function runSignupQuoteAnimation() {
@@ -143,7 +159,7 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     }
     try {
       const { error } = await state.sb.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}${window.location.pathname}`,
+        redirectTo: `${window.location.origin}${LOGIN_PATH}`,
       });
       if (error) throw error;
       utils.showToast('Password reset email sent');
@@ -188,11 +204,7 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     document.getElementById('app-container').inert = false;
     document.getElementById('bottom-nav').inert = false;
     state.lastFocusedBeforeWelcome = null;
-    const showSignup = shouldShowSignupByDefault();
-    document.getElementById('login-panel').hidden = showSignup;
-    document.getElementById('signup-panel').hidden = !showSignup;
-    if (showSignup) runSignupQuoteAnimation();
-    syncSignupStickyCta();
+    syncAuthPanelsToRoute();
   }
 
   function resolveInitialAuth(nextScreen) {
@@ -268,25 +280,38 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
   }
 
   function bindEvents() {
-    document.getElementById('show-signup-btn').onclick = () => {
-      document.getElementById('login-panel').hidden = true;
-      document.getElementById('signup-panel').hidden = false;
-      runSignupQuoteAnimation();
-      syncSignupStickyCta();
+    document.getElementById('show-signup-btn').onclick = e => {
+      e.preventDefault();
+      setAuthRoute('signup');
+      syncAuthPanelsToRoute();
     };
-    document.getElementById('show-login-btn').onclick = () => {
-      document.getElementById('signup-panel').hidden = true;
-      document.getElementById('login-panel').hidden = false;
-      syncSignupStickyCta();
+    document.getElementById('show-login-btn').onclick = e => {
+      e.preventDefault();
+      setAuthRoute('login');
+      syncAuthPanelsToRoute();
     };
     document.getElementById('forgot-password-btn').onclick = () => sendPasswordReset();
     document.getElementById('signup-sticky-cta').onclick = () => scrollToSignupForm();
+    document.getElementById('signup-hero-get-started').onclick = e => {
+      e.preventDefault();
+      scrollToSignupForm();
+    };
+    document.getElementById('signup-hero-sign-in').onclick = e => {
+      e.preventDefault();
+      setAuthRoute('login');
+      syncAuthPanelsToRoute();
+    };
 
     if (!document.getElementById('signup-panel').hidden) {
       runSignupQuoteAnimation();
     }
     syncSignupStickyCta();
     window.addEventListener('resize', syncSignupStickyCta);
+    window.addEventListener('popstate', () => {
+      if (!state.currentUser && !document.getElementById('auth-screen').hidden) {
+        syncAuthPanelsToRoute();
+      }
+    });
 
     ['login-email', 'login-password'].forEach(id => {
       document.getElementById(id).addEventListener('keydown', e => {
@@ -342,7 +367,13 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
       const btn = document.getElementById('signup-btn');
       btn.disabled = true;
       try {
-        const { data: userData, error } = await state.sb.auth.signUp({ email, password });
+        const { data: userData, error } = await state.sb.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: `${window.location.origin}${LOGIN_PATH}`,
+          },
+        });
         if (error) throw error;
         deps.markWelcomePending(userData.user?.id);
         if (!userData.session) {

--- a/auth.js
+++ b/auth.js
@@ -32,7 +32,6 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     document.getElementById('login-panel').hidden = showSignup;
     document.getElementById('signup-panel').hidden = !showSignup;
     if (showSignup) runSignupQuoteAnimation();
-    syncSignupStickyCta();
   }
 
   function runSignupQuoteAnimation() {
@@ -97,51 +96,6 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     if (firstInput) {
       window.setTimeout(() => firstInput.focus({ preventScroll: true }), 320);
     }
-  }
-
-  function disconnectSignupStickyObserver() {
-    if (state.signupStickyObserver) {
-      state.signupStickyObserver.disconnect();
-      state.signupStickyObserver = null;
-    }
-  }
-
-  function syncSignupStickyCta() {
-    const signupPanel = document.getElementById('signup-panel');
-    const inlineSignupBtn = document.getElementById('signup-btn');
-    const stickyWrap = document.getElementById('signup-sticky-cta-wrap');
-
-    if (!signupPanel || !inlineSignupBtn || !stickyWrap) return;
-
-    const isMobileViewport = window.matchMedia('(max-width: 768px)').matches;
-    const shouldHideSticky = signupPanel.hidden || !isMobileViewport;
-
-    if (shouldHideSticky) {
-      stickyWrap.classList.add('is-hidden');
-      disconnectSignupStickyObserver();
-      return;
-    }
-
-    if (!('IntersectionObserver' in window)) {
-      stickyWrap.classList.remove('is-hidden');
-      return;
-    }
-
-    stickyWrap.classList.remove('is-hidden');
-
-    if (state.signupStickyObserverTarget === inlineSignupBtn && state.signupStickyObserver) {
-      return;
-    }
-
-    disconnectSignupStickyObserver();
-    state.signupStickyObserverTarget = inlineSignupBtn;
-    state.signupStickyObserver = new window.IntersectionObserver((entries) => {
-      const [entry] = entries;
-      stickyWrap.classList.toggle('is-hidden', Boolean(entry?.isIntersecting));
-    }, {
-      threshold: 0.01,
-    });
-    state.signupStickyObserver.observe(inlineSignupBtn);
   }
 
   async function sendPasswordReset() {
@@ -291,7 +245,6 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
       syncAuthPanelsToRoute();
     };
     document.getElementById('forgot-password-btn').onclick = () => sendPasswordReset();
-    document.getElementById('signup-sticky-cta').onclick = () => scrollToSignupForm();
     document.getElementById('signup-hero-get-started').onclick = e => {
       e.preventDefault();
       scrollToSignupForm();
@@ -305,8 +258,6 @@ window.HabitsApp.registerAuthModule = function registerAuthModule(ctx) {
     if (!document.getElementById('signup-panel').hidden) {
       runSignupQuoteAnimation();
     }
-    syncSignupStickyCta();
-    window.addEventListener('resize', syncSignupStickyCta);
     window.addEventListener('popstate', () => {
       if (!state.currentUser && !document.getElementById('auth-screen').hidden) {
         syncAuthPanelsToRoute();

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
           <h1 class="auth-app-name">Habits</h1>
           <p class="auth-description">A personal daily habits tracker. Build the systems that make a healthy life feel automatic.</p>
           <div class="signup-hero-actions">
-            <a class="auth-primary-btn signup-hero-cta" id="signup-hero-get-started" href="#signup-form-card">Get started</a>
+            <a class="auth-primary-btn signup-hero-cta" id="signup-hero-get-started" href="#signup-form-card">Sign up</a>
             <a class="signup-hero-secondary-btn" id="signup-hero-sign-in" href="/login">Sign in</a>
           </div>
         </div>
@@ -116,9 +116,6 @@
         <p class="auth-switch">Already have an account?
           <a class="auth-link-btn" id="show-login-btn" href="/login">Sign in</a>
         </p>
-      </div>
-      <div class="signup-sticky-cta-wrap" id="signup-sticky-cta-wrap">
-        <button class="auth-primary-btn signup-sticky-cta" id="signup-sticky-cta" type="button">Create account</button>
       </div>
       <div class="auth-version-stamp" id="signup-version-stamp"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         <div class="auth-error" id="login-error" hidden></div>
         <button class="auth-primary-btn" id="login-btn">Sign in</button>
         <p class="auth-switch">Don't have an account?
-          <button class="auth-link-btn" id="show-signup-btn">Sign up</button>
+          <a class="auth-link-btn" id="show-signup-btn" href="/">Sign up</a>
         </p>
       </div>
       <div class="auth-version-stamp" id="login-version-stamp"></div>
@@ -77,6 +77,10 @@
         <div class="signup-hero-header">
           <h1 class="auth-app-name">Habits</h1>
           <p class="auth-description">A personal daily habits tracker. Build the systems that make a healthy life feel automatic.</p>
+          <div class="signup-hero-actions">
+            <a class="auth-primary-btn signup-hero-cta" id="signup-hero-get-started" href="#signup-form-card">Get started</a>
+            <a class="signup-hero-secondary-btn" id="signup-hero-sign-in" href="/login">Sign in</a>
+          </div>
         </div>
         <div class="signup-feature-grid" aria-label="Habits features">
           <article class="signup-feature-card">
@@ -110,7 +114,7 @@
         <div class="auth-error" id="signup-error" hidden></div>
         <button class="auth-primary-btn" id="signup-btn">Create account</button>
         <p class="auth-switch">Already have an account?
-          <button class="auth-link-btn" id="show-login-btn">Sign in</button>
+          <a class="auth-link-btn" id="show-login-btn" href="/login">Sign in</a>
         </p>
       </div>
       <div class="signup-sticky-cta-wrap" id="signup-sticky-cta-wrap">

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,11 @@
   # Skip secrets scanning for these files to prevent a false-positive build failure.
   SECRETS_SCAN_OMIT_PATHS = "app.js"
 
+[[redirects]]
+  from = "/login"
+  to = "/index.html"
+  status = 200
+
 [functions."keep-alive"]
   # Run once a day to prevent the Supabase free-tier project from pausing.
   # SUPABASE_URL and SUPABASE_KEY are read from Netlify environment variables at runtime.

--- a/style.css
+++ b/style.css
@@ -3141,6 +3141,13 @@
       margin-bottom: 22px;
     }
 
+    .signup-hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 6px;
+    }
+
     #signup-panel .auth-app-name,
     #signup-panel .auth-description {
       text-align: left;
@@ -3338,6 +3345,9 @@
     }
 
     .auth-primary-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       background: var(--accent);
       color: #fff;
       border: none;
@@ -3352,7 +3362,36 @@
       touch-action: manipulation;
       font-family: inherit;
       margin-top: 4px;
+      text-decoration: none;
       transition: background 0.15s, opacity 0.15s;
+    }
+
+    .signup-hero-cta {
+      width: auto;
+      margin-top: 0;
+      padding-left: 22px;
+      padding-right: 22px;
+    }
+
+    .signup-hero-secondary-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 52px;
+      padding: 0 22px;
+      border-radius: 14px;
+      border: 2px solid rgba(196, 181, 253, 0.28);
+      background: transparent;
+      color: var(--text-primary);
+      font-size: 1rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: background-color 0.15s, border-color 0.15s, opacity 0.15s;
+    }
+
+    .signup-hero-secondary-btn:active {
+      background: rgba(255, 255, 255, 0.04);
+      border-color: rgba(216, 193, 255, 0.5);
     }
 
     .auth-primary-btn:active {
@@ -3394,6 +3433,7 @@
       padding: 0;
       font-family: inherit;
       -webkit-tap-highlight-color: transparent;
+      text-decoration: none;
     }
 
     .auth-inline-link {
@@ -3423,6 +3463,15 @@
 
       .signup-feature-grid {
         grid-template-columns: 1fr;
+      }
+
+      .signup-hero-actions {
+        flex-direction: column;
+      }
+
+      .signup-hero-cta,
+      .signup-hero-secondary-btn {
+        width: 100%;
       }
 
       .signup-feature-card {

--- a/style.css
+++ b/style.css
@@ -3315,14 +3315,6 @@
         0 18px 50px rgba(0, 0, 0, 0.24);
     }
 
-    .signup-sticky-cta-wrap {
-      display: none;
-    }
-
-    .signup-sticky-cta {
-      margin-top: 0;
-    }
-
     .auth-input {
       background: var(--surface2);
       border: 1px solid var(--border);
@@ -3380,7 +3372,7 @@
       min-height: 52px;
       padding: 0 22px;
       border-radius: 14px;
-      border: 2px solid rgba(196, 181, 253, 0.28);
+      border: 2px solid rgba(216, 193, 255, 0.58);
       background: transparent;
       color: var(--text-primary);
       font-size: 1rem;
@@ -3448,7 +3440,7 @@
     @media (max-width: 768px) {
       #auth-screen {
         padding-top: calc(env(safe-area-inset-top, 0px) + 28px);
-        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 124px);
+        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 28px);
       }
 
       .signup-hero {
@@ -3456,22 +3448,18 @@
         border-radius: 26px;
       }
 
-      #signup-panel .auth-app-name,
-      #signup-panel .auth-description {
-        text-align: center;
-      }
-
       .signup-feature-grid {
         grid-template-columns: 1fr;
       }
 
       .signup-hero-actions {
-        flex-direction: column;
+        flex-wrap: nowrap;
       }
 
       .signup-hero-cta,
       .signup-hero-secondary-btn {
-        width: 100%;
+        width: calc(50% - 6px);
+        flex: 1 1 0;
       }
 
       .signup-feature-card {
@@ -3485,33 +3473,6 @@
 
       .signup-quote-text {
         min-height: 5.3em;
-      }
-
-      .signup-sticky-cta-wrap {
-        display: block;
-        position: fixed;
-        left: 16px;
-        right: 16px;
-        bottom: 0;
-        padding-bottom: env(safe-area-inset-bottom, 0px);
-        z-index: 340;
-        opacity: 1;
-        pointer-events: auto;
-        transition: opacity 240ms ease;
-      }
-
-      .signup-sticky-cta-wrap.is-hidden {
-        opacity: 0;
-        pointer-events: none;
-      }
-
-      .signup-sticky-cta {
-        width: calc(100% - 40px);
-        margin-left: 20px;
-        margin-right: 20px;
-        margin-top: 0;
-        margin-bottom: 14px;
-        box-shadow: 0 18px 44px rgba(91, 33, 182, 0.35);
       }
     }
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v34';
+const CACHE = 'habits-v35';
 const PRECACHE = [
   '/',
   '/index.html',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'habits-v35';
+const CACHE = 'habits-v36';
 const PRECACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- swap the unauthenticated default route so `/` shows the marketing/signup page and `/login` shows the sparse sign-in screen
- add hero CTAs on the marketing page, including a smooth-scroll "Get started" action and a secondary outlined link to `/login`
- add the Netlify `/login` rewrite, move auth email redirects to `/login`, and bump the shipped app/service-worker version pair

## Why
The public entry flow needs the marketing/signup experience at the root URL while keeping the existing login screen available on its own direct path.

## Validation
- `node --check auth.js`
- `node --check app.js`
- reviewed route, redirect, and version changes in the staged diff

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.5.36

* **New Features**
  * Authentication now uses dedicated login and signup pages, providing clearer separation between sign-in and signup experiences

* **Bug Fixes**
  * Password recovery links now properly redirect users to the login page for password reset

* **UI/UX Updates**
  * Modernized authentication screen navigation with improved interactive controls
  * Enhanced signup screen layout and refined visual styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisaug21/habits/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->